### PR TITLE
侧边导航超出窗口高度自动滚动

### DIFF
--- a/spug_web/src/layout/Sider.js
+++ b/spug_web/src/layout/Sider.js
@@ -74,7 +74,7 @@ class Sider extends React.Component {
 
   render() {
     return (
-      <Layout.Sider collapsed={this.props.collapsed}>
+      <Layout.Sider collapsed={this.props.collapsed} style={{height: '100vh', overflow: 'scroll'}}>
         <div className={styles.logo}>
           <img src={logo} alt="Logo"/>
           <img src={logoText} alt="logo-text" style={{marginLeft: 25, width: 70}} />

--- a/spug_web/src/layout/index.js
+++ b/spug_web/src/layout/index.js
@@ -30,8 +30,8 @@ export default class extends React.Component {
 
   render() {
     return (
-      <Layout style={{minHeight: '100vh'}}>
-        <Sider collapsed={this.state.collapsed}/>
+      <Layout>
+        <Sider collapsed={this.state.collapsed} />
         <Layout>
           <Header
             collapsed={this.state.collapsed}


### PR DESCRIPTION
从v2来的，刚看了demo，当导航全部展开时右边内容也同步滚动到最下，导致上面内容被遮挡。
刚调整了侧边导航，使其独立滚动。

**未进行npm run build**

before:
![](https://p1.ssl.qhimg.com/t01134e256ebd6ea8be.png)

after:
![](https://p5.ssl.qhimg.com/t017a94d1f25e0fa019.png)
