### PR TITLE
主机管理支持关联标签

### DIFF
--- a/spug_api/apps/host/models.py
+++ b/spug_api/apps/host/models.py
@@ -8,9 +8,21 @@ from apps.setting.utils import AppSetting
 from libs.ssh import SSH
 
 
+class Tag(models.Model, ModelMixin):
+    name = models.CharField(max_length=30)
+
+    def __str__(self):
+        return f'<Tag: {self.name}>'
+
+    class Meta:
+        db_table = 'tags'
+        ordering = ['name']
+
+
 class Host(models.Model, ModelMixin):
     name = models.CharField(max_length=50)
     zone = models.CharField(max_length=50)
+    tags = models.ManyToManyField(Tag)
     hostname = models.CharField(max_length=50)
     port = models.IntegerField()
     username = models.CharField(max_length=50)
@@ -24,6 +36,22 @@ class Host(models.Model, ModelMixin):
     def get_ssh(self, pkey=None):
         pkey = pkey or AppSetting.get('private_key')
         return SSH(self.hostname, self.port, self.username, pkey)
+
+    def to_dict(self):
+        res = {f.attname: getattr(self, f.attname) for f in self._meta.fields}
+        res['tags'] = []
+        for tag in self.tags.all():
+            res['tags'].append(tag.name)
+        return res
+
+    def update_tags(self, tags):
+        for tag in self.tags.all():
+            if tag.name not in tags:
+                self.tags.remove(tag)
+        for tag in tags:
+            t, created = Tag.objects.get_or_create(name=tag)
+            self.tags.add(t)
+        self.save()
 
     def __repr__(self):
         return '<Host %r>' % self.name

--- a/spug_api/apps/host/views.py
+++ b/spug_api/apps/host/views.py
@@ -5,7 +5,7 @@ from django.views.generic import View
 from django.db.models import F
 from libs import json_response, JsonParser, Argument
 from apps.setting.utils import AppSetting
-from apps.host.models import Host
+from apps.host.models import Host, Tag
 from apps.app.models import Deploy
 from apps.schedule.models import Task
 from apps.monitor.models import Detection
@@ -26,13 +26,15 @@ class HostView(View):
             return json_response(Host.objects.get(pk=host_id))
         hosts = Host.objects.filter(deleted_by_id__isnull=True)
         zones = [x['zone'] for x in hosts.order_by('zone').values('zone').distinct()]
+        tags = [tag.name for tag in Tag.objects.all() if tag.host_set.filter(deleted_by_id__isnull=True).count() > 0]
         perms = [x.id for x in hosts] if request.user.is_supper else request.user.host_perms
-        return json_response({'zones': zones, 'hosts': [x.to_dict() for x in hosts], 'perms': perms})
+        return json_response({'zones': zones, 'hosts': [x.to_dict() for x in hosts], 'perms': perms, 'tags': tags})
 
     def post(self, request):
         form, error = JsonParser(
             Argument('id', type=int, required=False),
             Argument('zone', help='请输入主机类型'),
+            Argument('tags', type=list, required=False),
             Argument('name', help='请输主机名称'),
             Argument('username', handler=str.strip, help='请输入登录用户名'),
             Argument('hostname', handler=str.strip, help='请输入主机名或IP'),
@@ -45,11 +47,17 @@ class HostView(View):
                 return json_response('auth fail')
 
             if form.id:
-                Host.objects.filter(pk=form.pop('id')).update(**form)
+                pk = form.pop('id')
+                Host.objects.filter(pk=pk).update(**{k: v for k, v in form.items() if k != 'tags'})
+                if 'tags' in form:
+                    host = Host.objects.get(pk=pk)
+                    host.update_tags(form.tags)
             elif Host.objects.filter(name=form.name, deleted_by_id__isnull=True).exists():
                 return json_response(error=f'已存在的主机名称【{form.name}】')
             else:
-                host = Host.objects.create(created_by=request.user, **form)
+                host = Host.objects.create(created_by=request.user, **{k: v for k, v in form.items() if k != 'tags'})
+                if 'tags' in form:
+                    host.update_tags(form.tags)
                 if request.user.role:
                     request.user.role.add_host_perm(host.id)
         return json_response(error=error)

--- a/spug_web/package.json
+++ b/spug_web/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@ant-design/icons": "^4.2.2",
     "@antv/data-set": "^0.10.2",
     "ace-builds": "^1.4.7",
     "antd": "^3.25.0",

--- a/spug_web/src/pages/exec/task/HostSelector.js
+++ b/spug_web/src/pages/exec/task/HostSelector.js
@@ -5,8 +5,9 @@
  */
 import React from 'react';
 import { observer } from 'mobx-react';
-import { Modal, Table, Input, Button, Select, Checkbox } from 'antd';
+import { Modal, Table, Input, Button, Select, Checkbox, Tag } from 'antd';
 import { SearchForm } from 'components';
+import Tags from '../../host/Tags'
 import store from '../../host/store';
 
 @observer
@@ -44,6 +45,9 @@ class HostSelector extends React.Component {
       if (store.f_zone) {
         data = data.filter(item => item['zone'].toLowerCase().includes(store.f_zone.toLowerCase()))
       }
+      if (store.selectedTags.length > 0) {
+        data = data.filter(item => store.selectedTags.every(tag => item['tags'].includes(tag)))
+      }
       this.setState({selectedRows: data})
     } else {
       this.setState({selectedRows: []})
@@ -58,6 +62,20 @@ class HostSelector extends React.Component {
   columns = [{
     title: '类别',
     dataIndex: 'zone',
+  }, {
+    title: '标签',
+    dataIndex: 'tags',
+    render: tags => (
+      <>
+        {tags.map(tag => (
+              <Tag key={tag}>
+                {tag}
+              </Tag>
+            )
+          )
+        }
+      </>
+    )
   }, {
     title: '主机名称',
     dataIndex: 'name',
@@ -83,6 +101,9 @@ class HostSelector extends React.Component {
     if (store.f_zone) {
       data = data.filter(item => item['zone'].toLowerCase().includes(store.f_zone.toLowerCase()))
     }
+    if (store.selectedTags.length > 0) {
+      data = data.filter(item => store.selectedTags.every(tag => item['tags'].includes(tag)))
+    }
     return (
       <Modal
         visible
@@ -107,6 +128,11 @@ class HostSelector extends React.Component {
           </SearchForm.Item>
           <SearchForm.Item span={4}>
             <Button type="primary" icon="sync" onClick={store.fetchRecords}>刷新</Button>
+          </SearchForm.Item>
+        </SearchForm>
+        <SearchForm>
+          <SearchForm.Item span={24}>
+            <Tags/>
           </SearchForm.Item>
         </SearchForm>
         <Table

--- a/spug_web/src/pages/host/Form.js
+++ b/spug_web/src/pages/host/Form.js
@@ -5,7 +5,8 @@
  */
 import React from 'react';
 import { observer } from 'mobx-react';
-import { Modal, Form, Input, Select, Col, Button, message } from 'antd';
+import { Modal, Form, Input, Select, Col, Button, Tag, Tooltip, message } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
 import http from 'libs/http';
 import store from './store';
 
@@ -18,13 +19,70 @@ class ComForm extends React.Component {
       password: null,
       addZone: null,
       editZone: store.record.zone,
+      tags: store.record.tags || [],
+      inputVisible: false,
+      inputValue: '',
+      editInputIndex: -1,
+      editInputValue: '',
     }
   }
+
+  handleCloseTag = removedTag => {
+    const tags = this.state.tags.filter(tag => tag !== removedTag);
+    this.setState({ tags });
+  };
+
+  showInputTag = () => {
+    this.setState({ inputVisible: true }, () => this.input.focus());
+  };
+
+  handleInputTagChange = e => {
+    this.setState({ inputValue: e.target.value });
+  };
+
+  handleInputTagConfirm = () => {
+    const { inputValue } = this.state;
+    let { tags } = this.state;
+    if (inputValue && tags.indexOf(inputValue) === -1) {
+      tags = [...tags, inputValue];
+    }
+    this.setState({
+      tags,
+      inputVisible: false,
+      inputValue: '',
+    });
+  };
+
+  handleEditInputChange = e => {
+    this.setState({ editInputValue: e.target.value });
+  };
+
+  handleEditInputConfirm = () => {
+    this.setState(({ tags, editInputIndex, editInputValue }) => {
+      const newTags = [...tags];
+      newTags[editInputIndex] = editInputValue;
+
+      return {
+        tags: newTags,
+        editInputIndex: -1,
+        editInputValue: '',
+      };
+    });
+  };
+
+  saveInputRef = input => {
+    this.input = input;
+  };
+
+  saveEditInputRef = input => {
+    this.editInput = input;
+  };
 
   handleSubmit = () => {
     this.setState({loading: true});
     const formData = this.props.form.getFieldsValue();
     formData['id'] = store.record.id;
+    formData['tags'] = this.state.tags;
     http.post('/api/host/', formData)
       .then(res => {
         if (res === 'auth fail') {
@@ -46,6 +104,7 @@ class ComForm extends React.Component {
   handleConfirm = (formData) => {
     if (this.state.password) {
       formData['password'] = this.state.password;
+      formData['tags'] = this.state.tags;
       return http.post('/api/host/', formData).then(res => {
         message.success('验证成功');
         store.formVisible = false;
@@ -112,6 +171,7 @@ class ComForm extends React.Component {
   render() {
     const info = store.record;
     const {getFieldDecorator} = this.props.form;
+    const { tags, inputVisible, inputValue, editInputIndex, editInputValue } = this.state;
     return (
       <Modal
         visible
@@ -139,6 +199,72 @@ class ComForm extends React.Component {
             <Col span={4} offset={1}>
               <Button type="link" onClick={this.handleEditZone}>编辑类别</Button>
             </Col>
+          </Form.Item>
+          <Form.Item label="标签">
+            {tags.map((tag, index) => {
+              if (editInputIndex === index) {
+                return (
+                  <Input
+                    ref={this.saveEditInputRef}
+                    key={tag}
+                    size="small"
+                    className="tag-input"
+                    value={editInputValue}
+                    onChange={this.handleEditInputChange}
+                    onBlur={this.handleEditInputConfirm}
+                    onPressEnter={this.handleEditInputConfirm}
+                  />
+                );
+              }
+
+              const isLongTag = tag.length > 20;
+
+              const tagElem = (
+                <Tag
+                  className="edit-tag"
+                  key={tag}
+                  closable={/*index !== 0*/true}
+                  onClose={() => this.handleCloseTag(tag)}
+                >
+                  <span
+                    onDoubleClick={e => {
+                      if (index !== 0) {
+                        this.setState({ editInputIndex: index, editInputValue: tag }, () => {
+                          this.editInput.focus();
+                        });
+                        e.preventDefault();
+                      }
+                    }}
+                  >
+                    {isLongTag ? `${tag.slice(0, 20)}...` : tag}
+                  </span>
+                </Tag>
+              );
+              return isLongTag ? (
+                <Tooltip title={tag} key={tag}>
+                  {tagElem}
+                </Tooltip>
+              ) : (
+                tagElem
+              );
+            })}
+            {inputVisible && (
+              <Input
+                ref={this.saveInputRef}
+                type="text"
+                size="small"
+                className="tag-input"
+                value={inputValue}
+                onChange={this.handleInputTagChange}
+                onBlur={this.handleInputTagConfirm}
+                onPressEnter={this.handleInputTagConfirm}
+              />
+            )}
+            {!inputVisible && (
+              <Tag className="site-tag-plus" onClick={this.showInputTag}>
+                <PlusOutlined /> New Tag
+              </Tag>
+            )}
           </Form.Item>
           <Form.Item required label="主机名称">
             {getFieldDecorator('name', {initialValue: info['name']})(

--- a/spug_web/src/pages/host/Table.js
+++ b/spug_web/src/pages/host/Table.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { observer } from 'mobx-react';
-import { Table, Divider, Modal, message } from 'antd';
+import { Table, Divider, Modal, Tag, message } from 'antd';
 import { LinkButton } from 'components';
 import ComForm from './Form';
 import ComImport from './Import';
@@ -26,6 +26,20 @@ class ComTable extends React.Component {
   }, {
     title: '类别',
     dataIndex: 'zone',
+  }, {
+    title: '标签',
+    dataIndex: 'tags',
+    render: tags => (
+      <>
+        {tags.map(tag => (
+              <Tag key={tag}>
+                {tag}
+              </Tag>
+            )
+          )
+        }
+      </>
+    )
   }, {
     title: '主机名称',
     dataIndex: 'name',
@@ -83,6 +97,9 @@ class ComTable extends React.Component {
     }
     if (store.f_host) {
       data = data.filter(item => item['hostname'].toLowerCase().includes(store.f_host.toLowerCase()))
+    }
+    if (store.selectedTags.length > 0) {
+      data = data.filter(item => store.selectedTags.every(tag => item['tags'].includes(tag)))
     }
     return (
       <React.Fragment>

--- a/spug_web/src/pages/host/Tags.js
+++ b/spug_web/src/pages/host/Tags.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) OpenSpug Organization. https://github.com/openspug/spug
+ * Copyright (c) <spug.dev@gmail.com>
+ * Released under the AGPL-3.0 License.
+ */
+import React from 'react';
+import { observer } from 'mobx-react';
+import { Tag } from 'antd';
+import store from './store';
+
+const { CheckableTag } = Tag;
+
+@observer
+class Tags extends React.Component {
+
+  handleChange = (tag, checked) => {
+    const selectedTags = store.selectedTags;
+    const nextSelectedTags = checked ? [...selectedTags, tag] : selectedTags.filter(t => t !== tag);
+    store.selectedTags = nextSelectedTags
+  }
+
+  render() {
+    const selectedTags = store.selectedTags;
+    return (
+      <>
+        <span style={{ marginRight: 8 }}>选择标签:</span>
+        {store.tagsData.map(tag => (
+          <CheckableTag
+            key={tag}
+            checked={selectedTags.indexOf(tag) > -1}
+            onChange={checked => this.handleChange(tag, checked)}
+          >
+            {tag}
+          </CheckableTag>
+        ))}
+      </>
+    );
+  }
+}
+
+export default Tags

--- a/spug_web/src/pages/host/index.js
+++ b/spug_web/src/pages/host/index.js
@@ -8,6 +8,7 @@ import { observer } from 'mobx-react';
 import { Input, Button, Select } from 'antd';
 import { SearchForm, AuthDiv, AuthCard } from 'components';
 import ComTable from './Table';
+import Tags from './Tags';
 import store from './store';
 
 export default observer(function () {
@@ -29,6 +30,11 @@ export default observer(function () {
         </SearchForm.Item>
         <SearchForm.Item span={6}>
           <Button type="primary" icon="sync" onClick={store.fetchRecords}>刷新</Button>
+        </SearchForm.Item>
+      </SearchForm>
+      <SearchForm>
+        <SearchForm.Item span={24}>
+          <Tags/>
         </SearchForm.Item>
       </SearchForm>
       <AuthDiv auth="host.host.add" style={{marginBottom: 16}}>

--- a/spug_web/src/pages/host/store.js
+++ b/spug_web/src/pages/host/store.js
@@ -20,12 +20,16 @@ class Store {
   @observable f_zone;
   @observable f_host;
 
+  @observable tagsData = [];
+  @observable selectedTags = [];
+
   fetchRecords = () => {
     this.isFetching = true;
     return http.get('/api/host/')
-      .then(({hosts, zones, perms}) => {
+      .then(({hosts, zones, tags, perms}) => {
         this.records = hosts;
         this.zones = zones;
+        this.tagsData = tags;
         this.permRecords = hosts.filter(item => perms.includes(item.id));
         for (let item of hosts) {
           this.idMap[item.id] = item

--- a/spug_web/yarn.lock
+++ b/spug_web/yarn.lock
@@ -25,6 +25,23 @@
     "@ant-design/colors" "^3.1.0"
     babel-runtime "^6.26.0"
 
+"@ant-design/icons-svg@^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz#480b025f4b20ef7fe8f47d4a4846e4fee84ea06c"
+  integrity sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
+
+"@ant-design/icons@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.2.2.tgz#6533c5a02aec49238ec4748074845ad7d85a4f5e"
+  integrity sha512-DrVV+wcupnHS7PehJ6KiTcJtAR5c25UMgjGECCc6pUT9rsvw0AuYG+a4HDjfxEQuDqKTHwW+oX/nIvCymyLE8Q==
+  dependencies:
+    "@ant-design/colors" "^3.1.0"
+    "@ant-design/icons-svg" "^4.0.0"
+    "@babel/runtime" "^7.10.4"
+    classnames "^2.2.6"
+    insert-css "^2.0.0"
+    rc-util "^5.0.1"
+
 "@ant-design/icons@~2.1.1":
   version "2.1.1"
   resolved "https://registry.npm.taobao.org/@ant-design/icons/download/@ant-design/icons-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40ant-design%2Ficons%2Fdownload%2F%40ant-design%2Ficons-2.1.1.tgz#7b9c08dffd4f5d41db667d9dbe5e0107d0bd9a4a"
@@ -1078,6 +1095,13 @@
   integrity sha1-ERp4ACpcJfyOM2G+3JUpxpa4Wmo=
   dependencies:
     regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.10.4":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0":
   version "7.6.0"
@@ -5696,6 +5720,11 @@ inquirer@^6.4.1:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
+  integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
+
 internal-ip@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
@@ -9460,6 +9489,14 @@ rc-util@^4.0.4, rc-util@^4.1.1, rc-util@^4.10.0, rc-util@^4.11.2, rc-util@^4.13.
     react-lifecycles-compat "^3.0.4"
     shallowequal "^0.2.2"
 
+rc-util@^5.0.1:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.0.7.tgz#125c3a2fd917803afbb685f9eadc789b085dc813"
+  integrity sha512-nr98b5aMqqvIqxm16nF+zC3K3f81r+HsflT5E9Encr5itRwV7Vo/5GjJMNds/WiFV33rilq7vzb3xeAbCycmwg==
+  dependencies:
+    react-is "^16.12.0"
+    shallowequal "^1.1.0"
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -9545,6 +9582,11 @@ react-error-overlay@^6.0.3:
   version "6.0.3"
   resolved "https://registry.npm.taobao.org/react-error-overlay/download/react-error-overlay-6.0.3.tgz#c378c4b0a21e88b2e159a3e62b2f531fd63bf60d"
   integrity sha1-w3jEsKIeiLLhWaPmKy9TH9Y79g0=
+
+react-is@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^16.6.0, react-is@^16.7.0:
   version "16.11.0"
@@ -9781,6 +9823,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
目前一台主机只能划分到一个类别下，当同一类服务部署在多台不同的主机，或者一台主机上部署有多个不同的服务时，为主机记录添加多对多的标签字段，可以更精确地筛选关联到某个或者某些标签的主机