### PR TITLE
主机管理支持关联标签

### DIFF
--- a/spug_web/package.json
+++ b/spug_web/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@ant-design/icons": "^4.2.2",
     "@antv/data-set": "^0.10.2",
     "ace-builds": "^1.4.7",
     "antd": "^3.25.0",

--- a/spug_web/src/pages/exec/task/HostSelector.js
+++ b/spug_web/src/pages/exec/task/HostSelector.js
@@ -5,8 +5,9 @@
  */
 import React from 'react';
 import { observer } from 'mobx-react';
-import { Modal, Table, Input, Button, Select } from 'antd';
+import { Modal, Table, Input, Button, Select, Tag } from 'antd';
 import { SearchForm } from 'components';
+import Tags from '../../host/Tags'
 import store from '../../host/store';
 
 @observer
@@ -44,6 +45,20 @@ class HostSelector extends React.Component {
     title: '类别',
     dataIndex: 'zone',
   }, {
+    title: '标签',
+    dataIndex: 'tags',
+    render: tags => (
+      <>
+        {tags.map(tag => (
+              <Tag key={tag}>
+                {tag}
+              </Tag>
+            )
+          )
+        }
+      </>
+    )
+  }, {
     title: '主机名称',
     dataIndex: 'name',
     ellipsis: true
@@ -67,6 +82,9 @@ class HostSelector extends React.Component {
     }
     if (store.f_zone) {
       data = data.filter(item => item['zone'].toLowerCase().includes(store.f_zone.toLowerCase()))
+    }
+    if (store.selectedTags.length > 0) {
+      data = data.filter(item => store.selectedTags.every(tag => item['tags'].includes(tag)))
     }
     const dataIds = data.map(x => x.id);
     return (
@@ -93,6 +111,11 @@ class HostSelector extends React.Component {
           </SearchForm.Item>
           <SearchForm.Item span={4}>
             <Button type="primary" icon="sync" onClick={store.fetchRecords}>刷新</Button>
+          </SearchForm.Item>
+        </SearchForm>
+        <SearchForm>
+          <SearchForm.Item span={24}>
+            <Tags/>
           </SearchForm.Item>
         </SearchForm>
         <Table

--- a/spug_web/src/pages/host/Table.js
+++ b/spug_web/src/pages/host/Table.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { observer } from 'mobx-react';
-import { Table, Divider, Modal, message } from 'antd';
+import { Table, Divider, Modal, Tag, message } from 'antd';
 import { LinkButton } from 'components';
 import ComForm from './Form';
 import ComImport from './Import';
@@ -26,6 +26,20 @@ class ComTable extends React.Component {
   }, {
     title: '类别',
     dataIndex: 'zone',
+  }, {
+    title: '标签',
+    dataIndex: 'tags',
+    render: tags => (
+      <>
+        {tags.map(tag => (
+              <Tag key={tag}>
+                {tag}
+              </Tag>
+            )
+          )
+        }
+      </>
+    )
   }, {
     title: '主机名称',
     dataIndex: 'name',
@@ -83,6 +97,9 @@ class ComTable extends React.Component {
     }
     if (store.f_host) {
       data = data.filter(item => item['hostname'].toLowerCase().includes(store.f_host.toLowerCase()))
+    }
+    if (store.selectedTags.length > 0) {
+      data = data.filter(item => store.selectedTags.every(tag => item['tags'].includes(tag)))
     }
     return (
       <React.Fragment>

--- a/spug_web/src/pages/host/Tags.js
+++ b/spug_web/src/pages/host/Tags.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) OpenSpug Organization. https://github.com/openspug/spug
+ * Copyright (c) <spug.dev@gmail.com>
+ * Released under the AGPL-3.0 License.
+ */
+import React from 'react';
+import { observer } from 'mobx-react';
+import { Tag } from 'antd';
+import store from './store';
+
+const { CheckableTag } = Tag;
+
+@observer
+class Tags extends React.Component {
+
+  handleChange = (tag, checked) => {
+    const selectedTags = store.selectedTags;
+    const nextSelectedTags = checked ? [...selectedTags, tag] : selectedTags.filter(t => t !== tag);
+    store.selectedTags = nextSelectedTags
+  }
+
+  render() {
+    const selectedTags = store.selectedTags;
+    return (
+      <>
+        <span style={{ marginRight: 8 }}>选择标签:</span>
+        {store.tagsData.map(tag => (
+          <CheckableTag
+            key={tag}
+            checked={selectedTags.indexOf(tag) > -1}
+            onChange={checked => this.handleChange(tag, checked)}
+          >
+            {tag}
+          </CheckableTag>
+        ))}
+      </>
+    );
+  }
+}
+
+export default Tags

--- a/spug_web/src/pages/host/index.js
+++ b/spug_web/src/pages/host/index.js
@@ -8,6 +8,7 @@ import { observer } from 'mobx-react';
 import { Input, Button, Select } from 'antd';
 import { SearchForm, AuthDiv, AuthCard } from 'components';
 import ComTable from './Table';
+import Tags from './Tags';
 import store from './store';
 
 export default observer(function () {
@@ -29,6 +30,11 @@ export default observer(function () {
         </SearchForm.Item>
         <SearchForm.Item span={6}>
           <Button type="primary" icon="sync" onClick={store.fetchRecords}>刷新</Button>
+        </SearchForm.Item>
+      </SearchForm>
+      <SearchForm>
+        <SearchForm.Item span={24}>
+          <Tags/>
         </SearchForm.Item>
       </SearchForm>
       <AuthDiv auth="host.host.add" style={{marginBottom: 16}}>

--- a/spug_web/src/pages/host/store.js
+++ b/spug_web/src/pages/host/store.js
@@ -20,12 +20,16 @@ class Store {
   @observable f_zone;
   @observable f_host;
 
+  @observable tagsData = [];
+  @observable selectedTags = [];
+
   fetchRecords = () => {
     this.isFetching = true;
     return http.get('/api/host/')
-      .then(({hosts, zones, perms}) => {
+      .then(({hosts, zones, tags, perms}) => {
         this.records = hosts;
         this.zones = zones;
+        this.tagsData = tags;
         this.permRecords = hosts.filter(item => perms.includes(item.id));
         for (let item of hosts) {
           this.idMap[item.id] = item

--- a/spug_web/yarn.lock
+++ b/spug_web/yarn.lock
@@ -25,6 +25,23 @@
     "@ant-design/colors" "^3.1.0"
     babel-runtime "^6.26.0"
 
+"@ant-design/icons-svg@^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz#480b025f4b20ef7fe8f47d4a4846e4fee84ea06c"
+  integrity sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
+
+"@ant-design/icons@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.2.2.tgz#6533c5a02aec49238ec4748074845ad7d85a4f5e"
+  integrity sha512-DrVV+wcupnHS7PehJ6KiTcJtAR5c25UMgjGECCc6pUT9rsvw0AuYG+a4HDjfxEQuDqKTHwW+oX/nIvCymyLE8Q==
+  dependencies:
+    "@ant-design/colors" "^3.1.0"
+    "@ant-design/icons-svg" "^4.0.0"
+    "@babel/runtime" "^7.10.4"
+    classnames "^2.2.6"
+    insert-css "^2.0.0"
+    rc-util "^5.0.1"
+
 "@ant-design/icons@~2.1.1":
   version "2.1.1"
   resolved "https://registry.npm.taobao.org/@ant-design/icons/download/@ant-design/icons-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40ant-design%2Ficons%2Fdownload%2F%40ant-design%2Ficons-2.1.1.tgz#7b9c08dffd4f5d41db667d9dbe5e0107d0bd9a4a"
@@ -1078,6 +1095,13 @@
   integrity sha1-ERp4ACpcJfyOM2G+3JUpxpa4Wmo=
   dependencies:
     regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.10.4":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0":
   version "7.6.0"
@@ -5695,6 +5719,11 @@ inquirer@^6.4.1:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
+  integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
+
 internal-ip@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
@@ -9446,6 +9475,14 @@ rc-util@^4.0.4, rc-util@^4.1.1, rc-util@^4.10.0, rc-util@^4.11.2, rc-util@^4.13.
     react-lifecycles-compat "^3.0.4"
     shallowequal "^0.2.2"
 
+rc-util@^5.0.1:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.0.7.tgz#125c3a2fd917803afbb685f9eadc789b085dc813"
+  integrity sha512-nr98b5aMqqvIqxm16nF+zC3K3f81r+HsflT5E9Encr5itRwV7Vo/5GjJMNds/WiFV33rilq7vzb3xeAbCycmwg==
+  dependencies:
+    react-is "^16.12.0"
+    shallowequal "^1.1.0"
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -9531,6 +9568,11 @@ react-error-overlay@^6.0.3:
   version "6.0.3"
   resolved "https://registry.npm.taobao.org/react-error-overlay/download/react-error-overlay-6.0.3.tgz#c378c4b0a21e88b2e159a3e62b2f531fd63bf60d"
   integrity sha1-w3jEsKIeiLLhWaPmKy9TH9Y79g0=
+
+react-is@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^16.6.0, react-is@^16.7.0:
   version "16.11.0"
@@ -9767,6 +9809,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
目前一台主机只能划分到一个类别下，当同一类服务部署在多台不同的主机，或者一台主机上部署有多个不同的服务时，为主机记录添加多对多的标签字段，可以更精确地筛选关联到某个或者某些标签的主机