### PR TITLE
修复在Table全屏下，Modal和Popover等组件不显示的问题

### DIFF
--- a/spug_web/src/components/TableCard.js
+++ b/spug_web/src/components/TableCard.js
@@ -92,6 +92,7 @@ function Header(props) {
           <ReloadOutlined onClick={props.onReload}/>
           <Popover
             arrowPointAtCenter
+            destroyTooltipOnHide={{keepParent: false}}
             title={[
               <Checkbox
                 key="1"

--- a/spug_web/src/index.js
+++ b/spug_web/src/index.js
@@ -5,26 +5,27 @@
  */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Router } from 'react-router-dom';
-import { ConfigProvider } from 'antd';
+import {Router} from 'react-router-dom';
+import {ConfigProvider} from 'antd';
 import zhCN from 'antd/es/locale/zh_CN';
 import './index.css';
 import App from './App';
 import moment from 'moment';
 import 'moment/locale/zh-cn';
 import * as serviceWorker from './serviceWorker';
-import { history, updatePermissions } from 'libs';
+import {history, updatePermissions} from 'libs';
 
 moment.locale('zh-cn');
 updatePermissions();
 
 ReactDOM.render(
-  <Router history={history}>
-    <ConfigProvider locale={zhCN}>
-      <App/>
-    </ConfigProvider>
-  </Router>,
-  document.getElementById('root')
+    <Router history={history}>
+        <ConfigProvider locale={zhCN}
+                        getPopupContainer={() => document.fullscreenElement ? document.fullscreenElement : document.body}>
+            <App/>
+        </ConfigProvider>
+    </Router>,
+    document.getElementById('root')
 );
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
在全局配置中添加getPopupContainer方法，当全屏元素存在时组件会挂载到全屏元素中，否则就挂载到body中(body是Antd组件默认挂载的位置)。

代码不小心格式化了，是否需要改回原来的样式