### PR TITLE
常规发布增加健康检查

### DIFF
--- a/spug_api/libs/healthcheck.py
+++ b/spug_api/libs/healthcheck.py
@@ -1,0 +1,84 @@
+# Copyright: (c) OpenSpug Organization. https://github.com/openspug/spug
+# Copyright: (c) <spug.dev@gmail.com>
+# Released under the AGPL-3.0 License.
+import socket
+import requests
+from time import sleep
+from datetime import datetime
+
+
+class HealthCheck:
+
+    def __init__(self, host, host_id=None, helper=None, url=None, is_https=False, **kwargs):
+        self.host = host
+        self.port = kwargs['check_port']
+        self.retry = kwargs['check_retry']
+        self.path = kwargs['check_path']
+        self.timeout = kwargs['check_timeout']
+        self.interval = kwargs['check_interval']
+        self.is_http_check = kwargs['is_http_check']
+        if not url and self.is_http_check:
+            self.url = "{protocol}://{host}:{port}{path}".format(
+                protocol="https" if is_https else "http",
+                host=self.host,
+                port=self.port,
+                path=self.path if self.path.startswith('/') else '/'+self.path
+            )
+        else:
+            self.url = url
+        self.host_id = host_id
+        self.helper = helper
+
+    def notify(self, message):
+        if self.helper:
+            self.helper.send_step(self.host_id, 4, "{} {} \r\n".format(datetime.now().strftime('%H:%M:%S'), message))
+        else:
+            print(message)
+
+    def is_health(self) -> bool:
+        if self.is_http_check:
+            return self.health_check_with_http()
+        else:
+            return self.health_check_with_tcp()
+
+    def health_check_with_tcp(self) -> bool:
+        for i in range(self.retry):
+            self.notify("第{}次TCP健康检查".format(i+1))
+            if self.is_tcp_can_connect():
+                return True
+            if i < self.retry-1:
+                sleep(self.interval)
+        return False
+
+    def health_check_with_http(self) -> bool:
+        for i in range(self.retry):
+            self.notify("第{}次HTTP健康检查".format(i+1))
+            if self.is_http_status_in_2xx_3xx():
+                return True
+            if i < self.retry-1:
+                sleep(self.interval)
+        return False
+
+    def is_tcp_can_connect(self) -> bool:
+        s = socket.socket()
+        s.settimeout(self.timeout)
+        try:
+            s.connect((self.host, self.port))
+            self.notify("第TCP健康检查:{}:{} Connected".format(self.host, self.port))
+            s.close()
+            return True
+        except socket.error as e:
+            self.notify("TCP健康检查:{}:{} --- {}".format(self.host, self.port, e))
+            return False
+
+    def is_http_status_in_2xx_3xx(self) -> bool:
+        try:
+            resp = requests.get(self.url, timeout=self.timeout)
+            self.notify("HTTP健康检查：{} status_code:{}".format(self.url, resp.status_code))
+            # 判断是否2xx 3xx
+            return 200 >= resp.status_code <= 399
+        except requests.exceptions.RequestException as e:
+            self.notify("HTTP健康检查：{} --- {}".format(self.url, e))
+            return False
+
+

--- a/spug_web/src/pages/deploy/app/Ext1Setup1.js
+++ b/spug_web/src/pages/deploy/app/Ext1Setup1.js
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from 'react';
 import { observer } from 'mobx-react';
 import { Link } from 'react-router-dom';
-import { Switch, Form, Input, Select, Button, Radio } from 'antd';
+import { Switch, Form, Input, Select, Button, Radio, InputNumber } from 'antd';
 import envStore from 'pages/config/environment/store';
 import Selector from 'pages/host/Selector';
 import store from './store';
@@ -77,6 +77,93 @@ export default observer(function Ext1Setup1() {
           <Radio.Button value={false}>串行</Radio.Button>
         </Radio.Group>
       </Form.Item>
+      {
+        !info['is_parallel']?(
+            <Form.Item label="串行并发">
+              <InputNumber min={1} max={info.host_ids.length}
+                           defaultValue={1}
+                           value={info.parallel_num}
+                           onChange={(value) => info['parallel_num'] = value}
+              />
+            </Form.Item>
+        ): null
+      }
+      <Form.Item label="健康检查">
+          <Switch
+              disabled={store.isReadOnly}
+              checkedChildren="开启"
+              unCheckedChildren="关闭"
+              checked={info['is_health_check_enabled']}
+              onChange={v => info['is_health_check_enabled'] = v}/>
+      </Form.Item>
+      {
+        info['is_health_check_enabled']?(
+          <>
+            <Form.Item label="健康检查方式">
+            <Radio.Group
+              buttonStyle="solid"
+              defaultValue={false}
+              value={info.is_http_check}
+              onChange={(e) => info['is_http_check'] = e.target.value}>
+              <Radio.Button value={false}>TCP</Radio.Button>
+              <Radio.Button value={true}>HTTP</Radio.Button>
+            </Radio.Group>
+            </Form.Item>
+            <Form.Item label="健康检查端口">
+              <InputNumber placeholder="8080" style={{ width: 120}} value={info.check_port}  onChange={(value) => info['check_port'] = value} />
+            </Form.Item>
+            {
+              info.is_http_check?(
+                <Form.Item label="健康检查URL">
+                <Input placeholder="/healthz" style={{ width: 500}} value={info.check_path} onChange={(e) => info['check_path'] = e.target.value} />
+              </Form.Item>
+              ):null
+            }
+            <Form.Item label="健康检查重试次数">
+              <InputNumber 
+                min={1} 
+                max={100} 
+                defaultValue={3} 
+                value={info.check_retry} 
+                addonAfter="次" 
+                style={{ width: 120}}
+                onChange={(value) => info['check_retry'] = value}
+              />
+            </Form.Item>
+            <Form.Item label="健康检查间隔时间">
+              <InputNumber 
+                min={1} 
+                defaultValue={60} 
+                value={info.check_interval} 
+                onChange={(value) => info['check_interval'] = value}
+                addonAfter="秒" 
+                style={{ width: 120}} 
+              />
+            </Form.Item>
+            <Form.Item label="健康检查超时时间">
+              <InputNumber 
+                min={1} 
+                defaultValue={30} 
+                value={info.check_timeout} 
+                onChange={(value) => info['check_timeout'] = value}
+                addonAfter="秒" 
+                style={{ width: 120}} 
+              />
+            </Form.Item>
+            <Form.Item label="健康检查失败">
+              <Select
+                defaultValue={0}
+                value={info.check_failed_action} 
+                onChange={(e) => info['check_failed_action'] = e.target.value}
+                style={{width: 120}} 
+                >
+                <Select.Option value={0}>终止发布</Select.Option>
+                <Select.Option value={1}>忽略继续</Select.Option>
+              </Select>
+            </Form.Item>
+          </>
+        ):null
+      }
       <Form.Item label="发布审核">
         <Switch
           disabled={store.isReadOnly}


### PR DESCRIPTION
解决这个Issue #417 

## 需求

我们之前在遇过因为包传输不完整、配置改错，代码问题等等原因导致发版后，服务未能正常启动。

所以希望在发布的时候，增加健康检查，这样发布有问题的服务就会暴露出来，及时把有问题服务影响范围缩小到第一次发布的几个机器。

比如10个副本，我们并行控制在2个，一旦健康检查通过，就会继续发布，如果不通过，就中断发布，把影响范围缩小。避免全都传输过去后，启动不了，影响正常业务。

## 功能

- 可自定义配置并行发布数量 分批次部署 （严格控制一次发版的数量，控制故障范围）
- 支持TCP和HTTP方式进行健康检查
- 可配置检查间隔和超时时间

## 健康检查判定

HTTP方式健康判定： 发送GET请求，HTTP状态为2xx和3xx都是正常的。

TCP方式健康判定： 创建套接字，进行TCP连接，能连接上指定端口则为健康。