### PR TITLE
 Issue #256 的两项核心能力

### DIFF
--- a/spug_api/apps/app/views.py
+++ b/spug_api/apps/app/views.py
@@ -7,6 +7,7 @@ from libs import JsonParser, Argument, json_response, auth
 from apps.app.models import App, Deploy, DeployExtend1, DeployExtend2
 from apps.config.models import Config, ConfigHistory, Service
 from apps.app.utils import fetch_versions, remove_repo
+from apps.host.utils import parse_group_host_ids
 from apps.setting.utils import AppSetting
 import json
 import re
@@ -125,17 +126,23 @@ class DeployView(View):
             Argument('id', type=int, required=False),
             Argument('app_id', type=int, help='请选择应用'),
             Argument('env_id', type=int, help='请选择环境'),
-            Argument('host_ids', type=list, filter=lambda x: len(x), help='请选择要部署的主机'),
+            Argument('host_ids', type=list, required=False, default=[]),
+            Argument('group_ids', type=list, required=False, default=[]),
             Argument('rst_notify', type=dict, help='请选择发布结果通知方式'),
             Argument('extend', filter=lambda x: x in dict(Deploy.EXTENDS), help='请选择发布类型'),
             Argument('is_parallel', type=bool, default=True),
             Argument('is_audit', type=bool, default=False)
         ).parse(request.body)
         if error is None:
+            host_ids = set(form.host_ids)
+            host_ids.update(parse_group_host_ids(form.group_ids))
+            if not host_ids:
+                return json_response(error='请选择要部署的主机')
             deploy = Deploy.objects.filter(app_id=form.app_id, env_id=form.env_id).first()
             if deploy and deploy.id != form.id:
                 return json_response(error='应用在该环境下已经存在发布配置')
-            form.host_ids = json.dumps(form.host_ids)
+            form.pop('group_ids')
+            form.host_ids = json.dumps(sorted(host_ids))
             form.rst_notify = json.dumps(form.rst_notify)
             if form.extend == '1':
                 extend_form, error = JsonParser(

--- a/spug_api/apps/deploy/utils.py
+++ b/spug_api/apps/deploy/utils.py
@@ -13,6 +13,7 @@ from apps.deploy.models import DeployRequest
 from apps.deploy.helper import Helper, SpugError
 from concurrent import futures
 from functools import partial
+import requests
 import json
 import uuid
 import os
@@ -141,7 +142,10 @@ def _ext2_deploy(req, helper, env):
         helper.send_info('local', f'\033[32m完成√\033[0m\r\n')
         for action in server_actions:
             helper.send_step('local', step, f'{human_time()} {action["title"]}...\r\n')
-            helper.local(f'cd /tmp && {action["data"]}', env)
+            if action.get('type') == 'jenkins':
+                _deploy_jenkins(helper, action, env)
+            else:
+                helper.local(f'cd /tmp && {action["data"]}', env)
             step += 1
 
     for action in host_actions:
@@ -219,6 +223,39 @@ def _ext2_deploy(req, helper, env):
     else:
         req.fail_host_ids = []
         helper.send_step('local', 100, f'\r\n{human_time()} ** 发布成功 **')
+
+
+def _deploy_jenkins(helper, action, env):
+    url = (action.get('url') or '').strip()
+    if not url:
+        helper.send_error('local', 'Jenkins URL is required')
+    auth = None
+    user = action.get('user')
+    token = action.get('token')
+    if user and token:
+        auth = (user, token)
+    try:
+        timeout = int(action.get('timeout') or 20)
+    except (TypeError, ValueError):
+        timeout = 20
+    params = {}
+    raw_params = action.get('params') or {}
+    if not isinstance(raw_params, dict):
+        raw_params = {}
+    for k, v in raw_params.items():
+        params[k] = render_str(str(v), env)
+    build_url = url.rstrip('/')
+    if params:
+        if not build_url.endswith('/buildWithParameters'):
+            build_url = f'{build_url}/buildWithParameters'
+    elif not build_url.endswith('/build'):
+        build_url = f'{build_url}/build'
+    helper.send_info('local', f'{human_time()} Trigger Jenkins: {build_url}\\r\\n')
+    response = requests.post(build_url, data=params or None, auth=auth, timeout=timeout)
+    if response.status_code not in (200, 201, 202):
+        helper.send_error('local', f'Jenkins trigger failed with status {response.status_code}: {response.text[:500]}')
+    queue_url = response.headers.get('Location') or '-'
+    helper.send_info('local', f'{human_time()} Jenkins accepted, queue url: {queue_url}\\r\\n')
 
 
 def _deploy_ext1_host(req, helper, h_id, env):

--- a/spug_api/apps/deploy/views.py
+++ b/spug_api/apps/deploy/views.py
@@ -11,6 +11,7 @@ from apps.deploy.models import DeployRequest
 from apps.app.models import Deploy, DeployExtend2
 from apps.repository.models import Repository
 from apps.deploy.utils import dispatch, Helper
+from apps.host.utils import parse_group_host_ids
 from apps.host.models import Host
 from collections import defaultdict
 from threading import Thread
@@ -18,6 +19,13 @@ from datetime import datetime
 import subprocess
 import json
 import os
+
+def merge_host_ids(host_ids, group_ids, limited_host_ids=None):
+    ids = set(host_ids or [])
+    ids.update(parse_group_host_ids(group_ids))
+    if limited_host_ids is not None:
+        ids = ids.intersection(set(limited_host_ids))
+    return sorted(ids)
 
 
 class RequestView(View):
@@ -211,13 +219,17 @@ def post_request_ext1(request):
         Argument('deploy_id', type=int, help='参数错误'),
         Argument('name', help='请输入申请标题'),
         Argument('extra', type=list, help='请选择发布版本'),
-        Argument('host_ids', type=list, filter=lambda x: len(x), help='请选择要部署的主机'),
+        Argument('host_ids', type=list, required=False, default=[]),
+        Argument('group_ids', type=list, required=False, default=[]),
         Argument('type', default='1'),
         Argument('plan', required=False),
         Argument('desc', required=False),
     ).parse(request.body)
     if error is None:
         deploy = Deploy.objects.get(pk=form.deploy_id)
+        host_ids = merge_host_ids(form.host_ids, form.group_ids, json.loads(deploy.host_ids))
+        if not host_ids:
+            return json_response(error='请选择要部署的主机')
         form.spug_version = Repository.make_spug_version(deploy.id)
         if form.extra[0] == 'tag':
             if not form.extra[1]:
@@ -240,7 +252,8 @@ def post_request_ext1(request):
 
         form.extra = json.dumps(form.extra)
         form.status = '0' if deploy.is_audit else '1'
-        form.host_ids = json.dumps(sorted(form.host_ids))
+        form.pop('group_ids')
+        form.host_ids = json.dumps(host_ids)
         if form.id:
             req = DeployRequest.objects.get(pk=form.id)
             is_required_notify = deploy.is_audit and req.status == '-1'
@@ -258,18 +271,23 @@ def post_request_ext1_rollback(request):
     form, error = JsonParser(
         Argument('request_id', type=int, help='请选择要回滚的版本'),
         Argument('name', help='请输入申请标题'),
-        Argument('host_ids', type=list, filter=lambda x: len(x), help='请选择要部署的主机'),
+        Argument('host_ids', type=list, required=False, default=[]),
+        Argument('group_ids', type=list, required=False, default=[]),
         Argument('desc', required=False),
     ).parse(request.body)
     if error is None:
         req = DeployRequest.objects.get(pk=form.pop('request_id'))
+        host_ids = merge_host_ids(form.host_ids, form.group_ids, json.loads(req.deploy.host_ids))
+        if not host_ids:
+            return json_response(error='请选择要部署的主机')
         requests = DeployRequest.objects.filter(deploy=req.deploy, status__in=('3', '-3'))
         versions = list({x.spug_version: 1 for x in requests}.keys())
         if req.spug_version not in versions[:req.deploy.extend_obj.versions + 1]:
             return json_response(error='选择的版本超出了发布配置中设置的版本数量，无法快速回滚，可通过新建发布申请选择构建仓库里的该版本再次发布。')
 
         form.status = '0' if req.deploy.is_audit else '1'
-        form.host_ids = json.dumps(sorted(form.host_ids))
+        form.pop('group_ids')
+        form.host_ids = json.dumps(host_ids)
         new_req = DeployRequest.objects.create(
             deploy_id=req.deploy_id,
             repository_id=req.repository_id,
@@ -291,7 +309,8 @@ def post_request_ext2(request):
         Argument('id', type=int, required=False),
         Argument('deploy_id', type=int, help='缺少必要参数'),
         Argument('name', help='请输申请标题'),
-        Argument('host_ids', type=list, filter=lambda x: len(x), help='请选择要部署的主机'),
+        Argument('host_ids', type=list, required=False, default=[]),
+        Argument('group_ids', type=list, required=False, default=[]),
         Argument('extra', type=dict, required=False),
         Argument('version', default=''),
         Argument('type', default='1'),
@@ -302,6 +321,9 @@ def post_request_ext2(request):
         deploy = Deploy.objects.filter(pk=form.deploy_id).first()
         if not deploy:
             return json_response(error='未找到该发布配置')
+        host_ids = merge_host_ids(form.host_ids, form.group_ids, json.loads(deploy.host_ids))
+        if not host_ids:
+            return json_response(error='请选择要部署的主机')
         extra = form.pop('extra')
         if DeployExtend2.objects.filter(deploy=deploy, host_actions__contains='"src_mode": "1"').exists():
             if not extra:
@@ -312,7 +334,8 @@ def post_request_ext2(request):
             form.spug_version = Repository.make_spug_version(deploy.id)
         form.name = form.name.replace("'", '')
         form.status = '0' if deploy.is_audit else '1'
-        form.host_ids = json.dumps(form.host_ids)
+        form.pop('group_ids')
+        form.host_ids = json.dumps(host_ids)
         if form.id:
             req = DeployRequest.objects.get(pk=form.id)
             is_required_notify = deploy.is_audit and req.status == '-1'

--- a/spug_api/apps/exec/views.py
+++ b/spug_api/apps/exec/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from libs import json_response, JsonParser, Argument, human_datetime, auth
 from apps.exec.models import ExecTemplate, ExecHistory
 from apps.host.models import Host
+from apps.host.utils import parse_group_host_ids
 from apps.account.utils import has_host_perm
 import uuid
 import json
@@ -61,13 +62,18 @@ class TaskView(View):
     @auth('exec.task.do')
     def post(self, request):
         form, error = JsonParser(
-            Argument('host_ids', type=list, filter=lambda x: len(x), help='请选择执行主机'),
+            Argument('host_ids', type=list, required=False, default=[]),
+            Argument('group_ids', type=list, required=False, default=[]),
             Argument('command', help='请输入执行命令内容'),
             Argument('interpreter', default='sh'),
             Argument('template_id', type=int, required=False),
             Argument('params', type=dict, handler=json.dumps, default={})
         ).parse(request.body)
         if error is None:
+            form.host_ids = sorted(set(form.host_ids).union(parse_group_host_ids(form.group_ids)))
+            if not form.host_ids:
+                return json_response(error='请选择执行主机')
+            form.pop('group_ids')
             if not has_host_perm(request.user, form.host_ids):
                 return json_response(error='无权访问主机，请联系管理员')
             token, rds = uuid.uuid4().hex, get_redis_connection()

--- a/spug_api/apps/host/utils.py
+++ b/spug_api/apps/host/utils.py
@@ -6,7 +6,7 @@ from libs.helper import make_ali_request, make_tencent_request
 from libs.ssh import SSH, AuthenticationException
 from libs.utils import AttrDict, human_datetime
 from libs.validators import ip_validator
-from apps.host.models import HostExtend
+from apps.host.models import HostExtend, Group
 from apps.setting.utils import AppSetting
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -301,3 +301,14 @@ def _get_ssh(kwargs, pkey=None, private_key=None, public_key=None, password=None
                 ssh.add_public_key(public_key)
             return _get_ssh(kwargs, private_key)
         raise e
+
+
+def parse_group_host_ids(group_ids):
+    group_ids = {int(x) for x in (group_ids or [])}
+    if not group_ids:
+        return set()
+    all_ids, sub_ids = set(group_ids), set(group_ids)
+    while sub_ids:
+        sub_ids = {x.id for x in Group.objects.filter(parent_id__in=sub_ids)}
+        all_ids.update(sub_ids)
+    return set(x.host_id for x in Group.hosts.through.objects.filter(group_id__in=all_ids))

--- a/spug_web/src/pages/deploy/app/AddSelect.js
+++ b/spug_web/src/pages/deploy/app/AddSelect.js
@@ -20,6 +20,7 @@ class AddSelect extends React.Component {
       is_audit: false,
       rst_notify: {mode: '0'},
       host_ids: [],
+      group_ids: [],
       filter_rule: {type: 'exclude', data: ''}
     }
   };
@@ -31,6 +32,7 @@ class AddSelect extends React.Component {
       is_audit: false,
       rst_notify: {mode: '0'},
       host_ids: [],
+      group_ids: [],
       host_actions: [],
       server_actions: []
     }

--- a/spug_web/src/pages/deploy/app/Ext1Setup1.js
+++ b/spug_web/src/pages/deploy/app/Ext1Setup1.js
@@ -10,6 +10,7 @@ import { Switch, Form, Input, Select, Button, Radio } from 'antd';
 import Repo from './Repo';
 import envStore from 'pages/config/environment/store';
 import HostSelector from 'pages/host/Selector';
+import hostStore from 'pages/host/store';
 import store from './store';
 
 export default observer(function Ext1Setup1() {
@@ -22,12 +23,28 @@ export default observer(function Ext1Setup1() {
   }
 
   useEffect(() => {
+    hostStore.initial()
+    if (!Array.isArray(store.deploy.group_ids)) {
+      store.deploy.group_ids = []
+    }
     if (store.currentRecord['deploys'] === undefined) {
       store.loadDeploys(store.app_id).then(updateEnvs)
     } else {
       updateEnvs()
     }
   }, [])
+
+  function handleChangeGroups(group_ids) {
+    info.group_ids = group_ids;
+    const host_ids = new Set(info.host_ids || []);
+    for (let id of group_ids) {
+      const counter = hostStore.counter[id];
+      if (counter) {
+        counter.forEach(h_id => host_ids.add(h_id))
+      }
+    }
+    info.host_ids = [...host_ids]
+  }
 
   const info = store.deploy;
   let modePlaceholder;
@@ -63,6 +80,18 @@ export default observer(function Ext1Setup1() {
       </Form.Item>
       <Form.Item required label="目标主机" tooltip="该发布配置作用于哪些目标主机。">
         <HostSelector value={info.host_ids} onChange={ids => info.host_ids = ids}/>
+      </Form.Item>
+      <Form.Item label="机器组选择" tooltip="可按机器组批量加入目标主机，之后仍可手动调整主机列表。">
+        <Select
+          mode="multiple"
+          allowClear
+          value={info.group_ids || []}
+          onChange={handleChangeGroups}
+          placeholder="请选择机器组">
+          {Object.entries(hostStore.groups).map(([id, name]) => (
+            <Select.Option key={id} value={Number(id)}>{name}</Select.Option>
+          ))}
+        </Select>
       </Form.Item>
       <Form.Item required label="Git仓库地址" extra={<span className="btn" onClick={() => setVisible(true)}>私有仓库？</span>}>
         <Input disabled={store.isReadOnly} value={info['git_repo']} onChange={e => info['git_repo'] = e.target.value}

--- a/spug_web/src/pages/deploy/app/Ext2Setup1.js
+++ b/spug_web/src/pages/deploy/app/Ext2Setup1.js
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import { Form, Switch, Select, Button, Input, Radio } from 'antd';
 import envStore from 'pages/config/environment/store';
 import HostSelector from 'pages/host/Selector';
+import hostStore from 'pages/host/store';
 import store from './store';
 
 export default observer(function Ext2Setup1() {
@@ -20,12 +21,28 @@ export default observer(function Ext2Setup1() {
   }
 
   useEffect(() => {
+    hostStore.initial()
+    if (!Array.isArray(store.deploy.group_ids)) {
+      store.deploy.group_ids = []
+    }
     if (store.currentRecord['deploys'] === undefined) {
       store.loadDeploys(store.app_id).then(updateEnvs)
     } else {
       updateEnvs()
     }
   }, [])
+
+  function handleChangeGroups(group_ids) {
+    info.group_ids = group_ids;
+    const host_ids = new Set(info.host_ids || []);
+    for (let id of group_ids) {
+      const counter = hostStore.counter[id];
+      if (counter) {
+        counter.forEach(h_id => host_ids.add(h_id))
+      }
+    }
+    info.host_ids = [...host_ids]
+  }
 
   const info = store.deploy;
   let modePlaceholder;
@@ -61,6 +78,18 @@ export default observer(function Ext2Setup1() {
       </Form.Item>
       <Form.Item required label="目标主机" tooltip="该发布配置作用于哪些目标主机。">
         <HostSelector value={info.host_ids} onChange={ids => info.host_ids = ids}/>
+      </Form.Item>
+      <Form.Item label="机器组选择" tooltip="可按机器组批量加入目标主机，之后仍可手动调整主机列表。">
+        <Select
+          mode="multiple"
+          allowClear
+          value={info.group_ids || []}
+          onChange={handleChangeGroups}
+          placeholder="请选择机器组">
+          {Object.entries(hostStore.groups).map(([id, name]) => (
+            <Select.Option key={id} value={Number(id)}>{name}</Select.Option>
+          ))}
+        </Select>
       </Form.Item>
       <Form.Item label="发布模式" tooltip="串行即发布时一台完成后再发布下一台，期间出现异常则终止发布。并行则每个主机相互独立发布同时进行。">
         <Radio.Group

--- a/spug_web/src/pages/deploy/app/Ext2Setup2.js
+++ b/spug_web/src/pages/deploy/app/Ext2Setup2.js
@@ -34,7 +34,26 @@ class Ext2Setup2 extends React.Component {
     info['app_id'] = store.app_id;
     info['extend'] = '2';
     info['host_actions'] = info['host_actions'].filter(x => (x.title && x.data) || (x.title && (x.src || x.src_mode === '1') && x.dst));
-    info['server_actions'] = info['server_actions'].filter(x => x.title && x.data);
+    const serverActions = [];
+    for (let item of info['server_actions']) {
+      if (item.type === 'jenkins') {
+        if (!item.title || !item.url) continue
+        let params = {};
+        if (item.params_text) {
+          try {
+            params = JSON.parse(item.params_text)
+          } catch (e) {
+            message.error(`Jenkins动作【${item.title || '未命名'}】参数必须是JSON对象`)
+            this.setState({loading: false});
+            return
+          }
+        }
+        serverActions.push({...item, params})
+      } else if (item.title && item.data) {
+        serverActions.push(item)
+      }
+    }
+    info['server_actions'] = serverActions;
     http.post('/api/app/deploy/', info)
       .then(res => {
         message.success('保存成功');
@@ -87,21 +106,73 @@ class Ext2Setup2 extends React.Component {
         {server_actions.map((item, index) => (
           <div key={index} style={{marginBottom: 30, position: 'relative'}}>
             <Form.Item required label={`本地动作${index + 1}`}>
-              <Input disabled={store.isReadOnly} value={item['title']} onChange={e => item['title'] = e.target.value}
-                     placeholder="请输入"/>
+              <Input
+                disabled={store.isReadOnly}
+                value={item['title']}
+                onChange={e => item['title'] = e.target.value}
+                placeholder="请输入"
+                addonAfter={(
+                  <Select
+                    disabled={store.isReadOnly}
+                    style={{width: 130}}
+                    value={item['type'] || 'shell'}
+                    onChange={v => item['type'] = v}>
+                    <Select.Option value="shell">脚本</Select.Option>
+                    <Select.Option value="jenkins">Jenkins</Select.Option>
+                  </Select>
+                )}/>
             </Form.Item>
-
-            <Form.Item required label="执行内容">
-              <ACEditor
-                readOnly={store.isReadOnly}
-                mode="sh"
-                theme="tomorrow"
-                width="100%"
-                height="100px"
-                value={item['data']}
-                onChange={v => item['data'] = cleanCommand(v)}
-                placeholder="请输入要执行的动作"/>
-            </Form.Item>
+            {item['type'] === 'jenkins' ? (
+              <React.Fragment>
+                <Form.Item required label="Jenkins Job URL">
+                  <Input
+                    disabled={store.isReadOnly}
+                    value={item['url']}
+                    onChange={e => item['url'] = e.target.value}
+                    placeholder="例如：https://jenkins.example.com/job/my-job"/>
+                </Form.Item>
+                <Form.Item label="认证用户名">
+                  <Input
+                    disabled={store.isReadOnly}
+                    value={item['user']}
+                    onChange={e => item['user'] = e.target.value}
+                    placeholder="可选"/>
+                </Form.Item>
+                <Form.Item label="API Token/Password">
+                  <Input.Password
+                    disabled={store.isReadOnly}
+                    value={item['token']}
+                    onChange={e => item['token'] = e.target.value}
+                    placeholder="可选"/>
+                </Form.Item>
+                <Form.Item label="触发超时(秒)">
+                  <Input
+                    disabled={store.isReadOnly}
+                    value={item['timeout'] || 20}
+                    onChange={e => item['timeout'] = Number(e.target.value || 20)}
+                    placeholder="20"/>
+                </Form.Item>
+                <Form.Item label="构建参数(JSON)">
+                  <Input.TextArea
+                    disabled={store.isReadOnly}
+                    value={item['params_text'] === undefined ? JSON.stringify(item['params'] || {}) : item['params_text']}
+                    onChange={e => item['params_text'] = e.target.value}
+                    placeholder='{"branch":"main","version":"$SPUG_RELEASE"}'/>
+                </Form.Item>
+              </React.Fragment>
+            ) : (
+              <Form.Item required label="执行内容">
+                <ACEditor
+                  readOnly={store.isReadOnly}
+                  mode="sh"
+                  theme="tomorrow"
+                  width="100%"
+                  height="100px"
+                  value={item['data']}
+                  onChange={v => item['data'] = cleanCommand(v)}
+                  placeholder="请输入要执行的动作"/>
+              </Form.Item>
+            )}
             {!store.isReadOnly && (
               <React.Fragment>
                 <Button type="dashed" icon={<UpOutlined/>} className={styles.upAction}
@@ -119,6 +190,13 @@ class Ext2Setup2 extends React.Component {
           <Form.Item wrapperCol={{span: 14, offset: 6}}>
             <Button type="dashed" block onClick={() => server_actions.push({})}>
               <PlusOutlined/>添加本地执行动作（在服务端本地执行）
+            </Button>
+            <Button
+              type="dashed"
+              block
+              style={{marginTop: 8}}
+              onClick={() => server_actions.push({type: 'jenkins', title: 'Jenkins发布', timeout: 20, params_text: '{}'})}>
+              <PlusOutlined/>添加 Jenkins 发布动作
             </Button>
           </Form.Item>
         )}
@@ -217,7 +295,10 @@ class Ext2Setup2 extends React.Component {
         <Form.Item wrapperCol={{span: 14, offset: 6}} style={{marginTop: 24}}>
           <Button
             type="primary"
-            disabled={store.isReadOnly || [...host_actions, ...server_actions].filter(x => x.title && x.data).length === 0}
+            disabled={store.isReadOnly || [...host_actions, ...server_actions].filter(x => {
+              if (x.type === 'jenkins') return x.title && x.url
+              return x.title && x.data
+            }).length === 0}
             loading={this.state.loading}
             onClick={this.handleSubmit}>提交</Button>
           <Button style={{marginLeft: 20}} onClick={() => store.page -= 1}>上一步</Button>

--- a/spug_web/src/pages/deploy/request/Ext1Form.js
+++ b/spug_web/src/pages/deploy/request/Ext1Form.js
@@ -10,6 +10,7 @@ import { LoadingOutlined, SyncOutlined } from '@ant-design/icons';
 import HostSelector from './HostSelector';
 import { http, history, includes } from 'libs';
 import store from './store';
+import hostStore from 'pages/host/store';
 import lds from 'lodash';
 import moment from 'moment';
 
@@ -32,6 +33,7 @@ export default observer(function () {
   const [loading, setLoading] = useState(false);
   const [repositories, setRepositories] = useState([]);
   const [host_ids, setHostIds] = useState([]);
+  const [group_ids, setGroupIds] = useState([]);
   const [plan, setPlan] = useState(store.record.plan);
   const [fetching, setFetching] = useState(false);
   const [git_type, setGitType] = useState();
@@ -43,9 +45,26 @@ export default observer(function () {
   useEffect(() => {
     const {app_host_ids, host_ids} = store.record;
     setHostIds(lds.clone(host_ids || app_host_ids));
+    hostStore.initial()
     fetchVersions()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  function handleChangeGroups(ids) {
+    setGroupIds(ids)
+    const selected = new Set(host_ids);
+    for (let id of ids) {
+      const counter = hostStore.counter[id];
+      if (counter) {
+        counter.forEach(h_id => {
+          if (app_host_ids.includes(h_id)) {
+            selected.add(h_id)
+          }
+        })
+      }
+    }
+    setHostIds([...selected])
+  }
 
   function fetchVersions() {
     setFetching(true);
@@ -70,6 +89,7 @@ export default observer(function () {
     formData['id'] = store.record.id;
     formData['deploy_id'] = store.record.deploy_id;
     formData['host_ids'] = host_ids;
+    formData['group_ids'] = group_ids;
     formData['type'] = store.record.type;
     formData['extra'] = [git_type, extra1, extra2];
     if (plan) formData.plan = plan.format('YYYY-MM-DD HH:mm:00');
@@ -231,6 +251,13 @@ export default observer(function () {
             <span style={{marginRight: 16}}>已选择 {host_ids.length} 台（可选{app_host_ids.length}）</span>
           )}
           <Button type="link" style={{padding: 0}} onClick={() => setVisible(true)}>选择主机</Button>
+        </Form.Item>
+        <Form.Item label="机器组选择" tooltip="可按机器组批量加入发布主机，之后仍可手动调整。">
+          <Select mode="multiple" allowClear value={group_ids} onChange={handleChangeGroups} placeholder="请选择机器组">
+            {Object.entries(hostStore.groups).map(([id, name]) => (
+              <Select.Option key={id} value={Number(id)}>{name}</Select.Option>
+            ))}
+          </Select>
         </Form.Item>
         <Form.Item name="desc" label="备注信息">
           <Input placeholder="请输入备注信息"/>

--- a/spug_web/src/pages/deploy/request/Ext2Form.js
+++ b/spug_web/src/pages/deploy/request/Ext2Form.js
@@ -6,11 +6,12 @@
 import React, { useState, useEffect } from 'react';
 import { observer } from 'mobx-react';
 import { UploadOutlined } from '@ant-design/icons';
-import { Modal, Form, Input, Upload, DatePicker, message, Button } from 'antd';
+import { Modal, Form, Input, Upload, DatePicker, message, Button, Select } from 'antd';
 import HostSelector from './HostSelector';
 import { http, clsNames, X_TOKEN } from 'libs';
 import styles from './index.module.less';
 import store from './store';
+import hostStore from 'pages/host/store';
 import lds from 'lodash';
 
 export default observer(function () {
@@ -20,13 +21,31 @@ export default observer(function () {
   const [uploading, setUploading] = useState(false);
   const [fileList, setFileList] = useState([]);
   const [host_ids, setHostIds] = useState([]);
+  const [group_ids, setGroupIds] = useState([]);
   const [plan, setPlan] = useState(store.record.plan);
 
   useEffect(() => {
     const {app_host_ids, host_ids, extra} = store.record;
     setHostIds(lds.clone(host_ids || app_host_ids));
+    hostStore.initial()
     if (store.record.extra) setFileList([{...extra, uid: '0'}])
   }, [])
+
+  function handleChangeGroups(ids) {
+    setGroupIds(ids)
+    const selected = new Set(host_ids);
+    for (let id of ids) {
+      const counter = hostStore.counter[id];
+      if (counter) {
+        counter.forEach(h_id => {
+          if (app_host_ids.includes(h_id)) {
+            selected.add(h_id)
+          }
+        })
+      }
+    }
+    setHostIds([...selected])
+  }
 
   function handleSubmit() {
     if (host_ids.length === 0) {
@@ -36,6 +55,7 @@ export default observer(function () {
     const formData = form.getFieldsValue();
     formData['id'] = store.record.id;
     formData['host_ids'] = host_ids;
+    formData['group_ids'] = group_ids;
     formData['type'] = store.record.type;
     formData['deploy_id'] = store.record.deploy_id;
     if (plan) formData.plan = plan.format('YYYY-MM-DD HH:mm:00');
@@ -102,6 +122,13 @@ export default observer(function () {
             <span style={{marginRight: 16}}>已选择 {host_ids.length} 台（可选{app_host_ids.length}）</span>
           )}
           <Button type="link" style={{padding: 0}} onClick={() => setVisible(true)}>选择主机</Button>
+        </Form.Item>
+        <Form.Item label="机器组选择" tooltip="可按机器组批量加入发布主机，之后仍可手动调整。">
+          <Select mode="multiple" allowClear value={group_ids} onChange={handleChangeGroups} placeholder="请选择机器组">
+            {Object.entries(hostStore.groups).map(([id, name]) => (
+              <Select.Option key={id} value={Number(id)}>{name}</Select.Option>
+            ))}
+          </Select>
         </Form.Item>
         <Form.Item name="desc" label="备注信息">
           <Input placeholder="请输入备注信息"/>

--- a/spug_web/src/pages/deploy/request/Rollback.js
+++ b/spug_web/src/pages/deploy/request/Rollback.js
@@ -9,6 +9,7 @@ import { Modal, Form, Input, Select, Button, message } from 'antd';
 import HostSelector from './HostSelector';
 import { http, includes } from 'libs';
 import store from './store';
+import hostStore from 'pages/host/store';
 import lds from 'lodash';
 import moment from 'moment';
 
@@ -17,12 +18,30 @@ export default observer(function () {
   const [visible, setVisible] = useState(false);
   const [loading, setLoading] = useState(false);
   const [host_ids, setHostIds] = useState([]);
+  const [group_ids, setGroupIds] = useState([]);
 
   useEffect(() => {
     const {app_host_ids, host_ids} = store.record;
     setHostIds(lds.clone(host_ids || app_host_ids));
+    hostStore.initial()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  function handleChangeGroups(ids) {
+    setGroupIds(ids)
+    const selected = new Set(host_ids);
+    for (let id of ids) {
+      const counter = hostStore.counter[id];
+      if (counter) {
+        counter.forEach(h_id => {
+          if (app_host_ids.includes(h_id)) {
+            selected.add(h_id)
+          }
+        })
+      }
+    }
+    setHostIds([...selected])
+  }
 
   function handleSubmit() {
     if (host_ids.length === 0) {
@@ -31,6 +50,7 @@ export default observer(function () {
     setLoading(true);
     const formData = form.getFieldsValue();
     formData['host_ids'] = host_ids;
+    formData['group_ids'] = group_ids;
     http.post('/api/deploy/request/ext1/rollback/', formData)
       .then(res => {
         message.success('操作成功');
@@ -73,6 +93,13 @@ export default observer(function () {
             <span style={{marginRight: 16}}>已选择 {host_ids.length} 台（可选{app_host_ids.length}）</span>
           )}
           <Button type="link" style={{padding: 0}} onClick={() => setVisible(true)}>选择主机</Button>
+        </Form.Item>
+        <Form.Item label="机器组选择" tooltip="可按机器组批量加入发布主机，之后仍可手动调整。">
+          <Select mode="multiple" allowClear value={group_ids} onChange={handleChangeGroups} placeholder="请选择机器组">
+            {Object.entries(hostStore.groups).map(([id, name]) => (
+              <Select.Option key={id} value={Number(id)}>{name}</Select.Option>
+            ))}
+          </Select>
         </Form.Item>
         <Form.Item name="desc" label="备注信息">
           <Input placeholder="请输入备注信息"/>

--- a/spug_web/src/pages/exec/task/index.js
+++ b/spug_web/src/pages/exec/task/index.js
@@ -6,7 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import { observer } from 'mobx-react';
 import { PlusOutlined, ThunderboltOutlined, BulbOutlined, QuestionCircleOutlined } from '@ant-design/icons';
-import { Form, Button, Radio, Tooltip } from 'antd';
+import { Form, Button, Radio, Tooltip, Select } from 'antd';
 import { ACEditor, AuthDiv, Breadcrumb } from 'components';
 import HostSelector from 'pages/host/Selector';
 import TemplateSelector from './TemplateSelector';
@@ -15,6 +15,7 @@ import Output from './Output';
 import { http, cleanCommand } from 'libs';
 import moment from 'moment';
 import store from './store';
+import hostStore from 'pages/host/store';
 import gStore from 'gStore';
 import style from './index.module.less';
 
@@ -25,6 +26,7 @@ function TaskIndex() {
   const [template_id, setTemplateId] = useState()
   const [histories, setHistories] = useState([])
   const [parameters, setParameters] = useState([])
+  const [group_ids, setGroupIds] = useState([])
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -41,6 +43,7 @@ function TaskIndex() {
   }, [command])
 
   useEffect(() => {
+    hostStore.initial()
     gStore.fetchUserSettings()
     return () => {
       store.host_ids = []
@@ -55,10 +58,29 @@ function TaskIndex() {
       return setVisible(true)
     }
     setLoading(true)
-    const formData = {interpreter, template_id, params, host_ids: store.host_ids, command: cleanCommand(command)}
+    const formData = {
+      interpreter,
+      template_id,
+      params,
+      host_ids: store.host_ids,
+      group_ids,
+      command: cleanCommand(command)
+    }
     http.post('/api/exec/do/', formData)
       .then(store.switchConsole)
       .finally(() => setLoading(false))
+  }
+
+  function handleChangeGroups(ids) {
+    setGroupIds(ids)
+    const selected = new Set(store.host_ids);
+    for (let id of ids) {
+      const counter = hostStore.counter[id];
+      if (counter) {
+        counter.forEach(h_id => selected.add(h_id))
+      }
+    }
+    store.host_ids = [...selected]
   }
 
   function handleTemplate(tpl) {
@@ -88,6 +110,13 @@ function TaskIndex() {
         <Form layout="vertical" className={style.left}>
           <Form.Item required label="目标主机">
             <HostSelector type="button" value={store.host_ids} onChange={ids => store.host_ids = ids}/>
+          </Form.Item>
+          <Form.Item label="机器组选择" tooltip="可按机器组批量加入主机，之后仍可手动调整。">
+            <Select mode="multiple" allowClear value={group_ids} onChange={handleChangeGroups} placeholder="请选择机器组">
+              {Object.entries(hostStore.groups).map(([id, name]) => (
+                <Select.Option key={id} value={Number(id)}>{name}</Select.Option>
+              ))}
+            </Select>
           </Form.Item>
 
           <Form.Item required label="执行命令" style={{position: 'relative'}}>


### PR DESCRIPTION
## 概要
本 PR 实现了 Issue #256 的两项核心能力：
1. 发布配置与执行流程支持“按机器组选择目标主机”。
2. 自定义发布（Ext2）支持 Jenkins 发布动作。

## 背景与问题
当前在主机数量较多时，发布配置和批量执行都需要逐台选择主机，操作成本高且容易遗漏。
同时，部分团队发布链路依赖 Jenkins，需要在发布流程中直接触发 Jenkins Job。

## 变更内容
### 一、机器组选择能力
- 新增机器组解析能力：
  - `spug_api/apps/host/utils.py`
  - 增加 `parse_group_host_ids(group_ids)`，支持递归解析分组与子分组下的主机。

- 发布配置接口支持 `group_ids`：
  - `spug_api/apps/app/views.py`
  - `/api/app/deploy/` 支持同时传入 `host_ids` 与 `group_ids`，后端合并去重后落库为最终 `host_ids`。

- 发布申请接口支持 `group_ids`：
  - `spug_api/apps/deploy/views.py`
  - 覆盖普通发布（ext1）、自定义发布（ext2）、回滚发布（ext1/rollback）。
  - 增加目标过滤逻辑，确保申请单主机范围不超出发布配置允许范围。

- 批量执行接口支持 `group_ids`：
  - `spug_api/apps/exec/views.py`
  - `/api/exec/do/` 支持机器组入参，扩展主机后继续复用现有权限校验逻辑。

- 前端增加机器组选择入口与参数透传：
  - 发布配置页面：
    - `spug_web/src/pages/deploy/app/Ext1Setup1.js`
    - `spug_web/src/pages/deploy/app/Ext2Setup1.js`
    - `spug_web/src/pages/deploy/app/AddSelect.js`
  - 发布申请页面：
    - `spug_web/src/pages/deploy/request/Ext1Form.js`
    - `spug_web/src/pages/deploy/request/Ext2Form.js`
    - `spug_web/src/pages/deploy/request/Rollback.js`
  - 批量执行页面：
    - `spug_web/src/pages/exec/task/index.js`
  - 行为说明：机器组选择为增量加入，仍可手工微调主机列表，保持原有按主机选择方式兼容。

### 二、Jenkins 发布支持
- 在 Ext2 服务端动作中新增 Jenkins 类型：
  - `spug_api/apps/deploy/utils.py`
  - 新增 `type: "jenkins"` 动作处理逻辑，可触发 Jenkins Job：
    - 无参数时调用 `/build`
    - 有参数时调用 `/buildWithParameters`
  - 支持配置项：
    - Jenkins URL
    - 用户名 + Token（可选）
    - 构建参数（JSON）
    - 超时时间
  - 增加执行日志与失败提示，便于排障。

- 前端新增 Jenkins 动作编辑能力：
  - `spug_web/src/pages/deploy/app/Ext2Setup2.js`
  - 服务端动作可选择“脚本 / Jenkins”类型。
  - Jenkins 类型支持填写 URL、认证信息、超时、参数 JSON，并在提交前做参数合法性校验。

## 兼容性说明
- 原有按主机选择流程保持可用。
- 机器组能力为增强，不影响既有数据结构的主流程。
- Jenkins 发布为可选动作，仅在配置后生效，不影响普通脚本动作执行。

## 验证情况
### 已完成
- 后端语法校验通过：
  - `python3 -m compileall` 已覆盖并通过以下文件：
    - `spug_api/apps/app/views.py`
    - `spug_api/apps/deploy/views.py`
    - `spug_api/apps/deploy/utils.py`
    - `spug_api/apps/exec/views.py`
    - `spug_api/apps/host/utils.py`

### 当前环境未完成
- 前端构建验证尝试执行：
  - `npm --prefix spug_web run build`
- 结果：
  - 本地环境缺少 `react-app-rewired`，命令未成功执行。

## 风险与回归建议
- 风险点主要在目标主机合并逻辑与 Ext2 服务端动作分支。
- Jenkins 动作为新增分支，建议重点验证错误场景与超时场景。

建议回归：
1. 发布配置中仅选机器组、仅选主机、主机+机器组混合选择。
2. ext1/ext2/rollback 三类申请均用机器组发起并检查目标主机是否符合预期。
3. 批量执行中机器组选择后的权限校验与执行结果。
4. Jenkins 动作在成功、认证失败、参数错误、超时下的日志与状态表现。