### PR TITLE
fix(alarm): schedule/account dialog white screen when no push contacts (#744)

### DIFF
--- a/spug_api/libs/push.py
+++ b/spug_api/libs/push.py
@@ -21,10 +21,11 @@ def get_contacts(token):
     try:
         res = requests.post(f'{push_server}/spug/contacts/', json={'token': token})
         res = res.json()
-        if res['data']:
+        if res.get('data'):
             return res['data']
     except Exception:
-        return []
+        pass
+    return []
 
 
 def send_login_code(token, user, code):

--- a/spug_web/src/pages/schedule/Step1.js
+++ b/spug_web/src/pages/schedule/Step1.js
@@ -18,7 +18,7 @@ export default observer(function () {
     const {mode, value} = store.record.rst_notify
     setRstValue({[mode]: value})
     http.get('/api/alarm/contact/?only_push=1')
-      .then(res => setContacts(res))
+      .then(res => setContacts(res || []))
   }, []);
 
   function handleAddZone() {

--- a/spug_web/src/pages/system/account/Form.js
+++ b/spug_web/src/pages/system/account/Form.js
@@ -19,7 +19,7 @@ export default observer(function () {
 
   useEffect(() => {
     http.get('/api/alarm/contact/?only_push=1')
-      .then(res => setContacts(res))
+      .then(res => setContacts(res || []))
   }, []);
 
   function handleSubmit() {


### PR DESCRIPTION
## Related Issue
Fixes #744

## Root Cause
Opening the **New / Edit** dialog of a scheduled task instantly white-screens the page when no alarm contacts have been added; the user is forced to log in again.

Root cause: when `spug_push_key` is unset (no push helper bound) or the push service returns an empty `data` payload, `get_contacts` in `spug_api/libs/push.py` implicitly returns `None`, so the endpoint `/api/alarm/contact/?only_push=1` responds with `null`.

On the frontend, `spug_web/src/pages/schedule/Step1.js` and `spug_web/src/pages/system/account/Form.js` call `setContacts(res)` directly, after which `contacts.map(...)` is invoked on `null` and throws, crashing the whole dialog into a white screen.

## Fix
1. **Backend `spug_api/libs/push.py`**: `get_contacts` now always returns a list — `[]` for both empty `data` and request exceptions — guaranteeing a consistent array contract. Also switched `res['data']` to `res.get('data')` to avoid a `KeyError` when the key is missing.
2. **Frontend `schedule/Step1.js` / `system/account/Form.js`**: guard the response with `setContacts(res || [])` so the dialog opens normally even if the backend ever returns `null`.

## Files Changed
- `spug_api/libs/push.py`
- `spug_web/src/pages/schedule/Step1.js`
- `spug_web/src/pages/system/account/Form.js`

## Affected Versions
- **Branch / release line**: `3.0` (Spug v3.3.3+, up to current `3.0` HEAD `10ae913`).
- The bug does **not** affect `4.0`: that branch has already refactored the schedule flow and removed the `only_push` contact lookup from `Step1`; its `alarm/views.py` `ContactView.get` simply returns `Contact.objects.all()` and does not call `get_contacts`.
- `master` (legacy 1.x line) is unaffected — it predates the push-contact integration.

## Verification
- With zero alarm contacts, opening the schedule **New / Edit** dialog no longer white-screens; the form can be filled and saved normally.
- With the push helper unbound, or bound but with an invalid token, the endpoint returns `[]`; the push-target dropdown is empty and the rest of the task behavior is unaffected.
- Adding / removing the first contact does not change unrelated task behavior.
- The `system/account` form is fixed by the same guard and no longer white-screens either.

## Scope of Change
Only the defensive loading of the push-contact dropdown in the **Schedule** and **Account** forms; no business validation or submit behavior is changed.

## Regression Risk
Low. The backend only tightens the return type to an array; the frontend only adds a null guard. Non-empty response paths behave exactly as before.