### PR TITLE
feat(deploy): add rollback support for custom (ext2) deploys (#731)

### DIFF
--- a/spug_api/apps/app/models.py
+++ b/spug_api/apps/app/models.py
@@ -110,11 +110,15 @@ class DeployExtend2(models.Model, ModelMixin):
     server_actions = models.TextField()
     host_actions = models.TextField()
     require_upload = models.BooleanField(default=False)
+    rollback_server_actions = models.TextField(null=True)
+    rollback_host_actions = models.TextField(null=True)
 
     def to_dict(self, *args, **kwargs):
         tmp = super().to_dict(*args, **kwargs)
         tmp['server_actions'] = json.loads(self.server_actions)
         tmp['host_actions'] = json.loads(self.host_actions)
+        tmp['rollback_server_actions'] = json.loads(self.rollback_server_actions) if self.rollback_server_actions else []
+        tmp['rollback_host_actions'] = json.loads(self.rollback_host_actions) if self.rollback_host_actions else []
         return tmp
 
     def __repr__(self):

--- a/spug_api/apps/app/views.py
+++ b/spug_api/apps/app/views.py
@@ -165,7 +165,9 @@ class DeployView(View):
             elif form.extend == '2':
                 extend_form, error = JsonParser(
                     Argument('server_actions', type=list, help='请输入执行动作'),
-                    Argument('host_actions', type=list, help='请输入执行动作')
+                    Argument('host_actions', type=list, help='请输入执行动作'),
+                    Argument('rollback_server_actions', type=list, default=[]),
+                    Argument('rollback_host_actions', type=list, default=[]),
                 ).parse(request.body)
                 if error:
                     return json_response(error=error)
@@ -174,6 +176,8 @@ class DeployView(View):
                 extend_form.require_upload = any(x.get('src_mode') == '1' for x in extend_form.host_actions)
                 extend_form.server_actions = json.dumps(extend_form.server_actions)
                 extend_form.host_actions = json.dumps(extend_form.host_actions)
+                extend_form.rollback_server_actions = json.dumps(extend_form.rollback_server_actions)
+                extend_form.rollback_host_actions = json.dumps(extend_form.rollback_host_actions)
                 if form.id:
                     Deploy.objects.filter(pk=form.id).update(**form)
                     DeployExtend2.objects.filter(deploy_id=form.id).update(**extend_form)

--- a/spug_api/apps/deploy/ext2.py
+++ b/spug_api/apps/deploy/ext2.py
@@ -17,8 +17,14 @@ REPOS_DIR = settings.REPOS_DIR
 def ext2_deploy(req, helper, env, with_local):
     flag = time.time()
     extend, step = req.deploy.extend_obj, 1
-    host_actions = json.loads(extend.host_actions)
-    server_actions = json.loads(extend.server_actions)
+    if req.type == '2':
+        host_actions = json.loads(extend.rollback_host_actions) if extend.rollback_host_actions else []
+        server_actions = json.loads(extend.rollback_server_actions) if extend.rollback_server_actions else []
+        if not host_actions and not server_actions:
+            helper.send_error('local', '该发布配置未设置回滚动作，无法回滚')
+    else:
+        host_actions = json.loads(extend.host_actions)
+        server_actions = json.loads(extend.server_actions)
     env.update({'SPUG_RELEASE': req.version})
     if req.version:
         for index, value in enumerate(req.version.split()):

--- a/spug_api/apps/deploy/urls.py
+++ b/spug_api/apps/deploy/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('request/ext1/', post_request_ext1),
     path('request/ext1/rollback/', post_request_ext1_rollback),
     path('request/ext2/', post_request_ext2),
+    path('request/ext2/rollback/', post_request_ext2_rollback),
     path('request/upload/', do_upload),
     path('request/<int:r_id>/', RequestDetailView.as_view()),
 ]

--- a/spug_api/apps/deploy/utils.py
+++ b/spug_api/apps/deploy/utils.py
@@ -24,7 +24,12 @@ def dispatch_all(req):
         if not req.repository_id:
             with_local = True
     else:
-        if json.loads(req.deploy.extend_obj.server_actions):
+        extend_obj = req.deploy.extend_obj
+        if req.type == '2':
+            server_actions = json.loads(extend_obj.rollback_server_actions) if extend_obj.rollback_server_actions else []
+        else:
+            server_actions = json.loads(extend_obj.server_actions)
+        if server_actions:
             with_local = True
     dispatch(req, host_ids, with_local)
 

--- a/spug_api/apps/deploy/views.py
+++ b/spug_api/apps/deploy/views.py
@@ -27,6 +27,12 @@ class RequestView(View):
             perms = request.user.deploy_perms
             query['deploy__app_id__in'] = perms['apps']
             query['deploy__env_id__in'] = perms['envs']
+        rollback_deploys = set()
+        for ext2 in DeployExtend2.objects.all():
+            s_acts = json.loads(ext2.rollback_server_actions) if ext2.rollback_server_actions else []
+            h_acts = json.loads(ext2.rollback_host_actions) if ext2.rollback_host_actions else []
+            if s_acts or h_acts:
+                rollback_deploys.add(ext2.deploy_id)
         for item in DeployRequest.objects.filter(**query).annotate(
                 env_id=F('deploy__env_id'),
                 env_name=F('deploy__env__name'),
@@ -55,6 +61,9 @@ class RequestView(View):
             tmp['do_by_user'] = item.do_by_user
             if item.app_extend == '1':
                 tmp['visible_rollback'] = item.deploy_id not in counter
+                counter[item.deploy_id] = True
+            elif item.app_extend == '2':
+                tmp['visible_rollback'] = item.deploy_id in rollback_deploys and item.deploy_id not in counter
                 counter[item.deploy_id] = True
             data.append(tmp)
         return json_response(data)
@@ -106,8 +115,13 @@ class RequestDetailView(View):
         outputs = {x.id: {'id': x.id, 'title': x.name, 'data': ''} for x in hosts}
         outputs['local'] = {'id': 'local', 'data': ''}
         if req.deploy.extend == '2':
-            s_actions = json.loads(req.deploy.extend_obj.server_actions)
-            h_actions = json.loads(req.deploy.extend_obj.host_actions)
+            extend_obj = req.deploy.extend_obj
+            if req.type == '2':
+                s_actions = json.loads(extend_obj.rollback_server_actions) if extend_obj.rollback_server_actions else []
+                h_actions = json.loads(extend_obj.rollback_host_actions) if extend_obj.rollback_host_actions else []
+            else:
+                s_actions = json.loads(extend_obj.server_actions)
+                h_actions = json.loads(extend_obj.host_actions)
             if not s_actions:
                 outputs.pop('local', None)
             if not h_actions and 'local' in outputs:
@@ -164,8 +178,13 @@ class RequestDetailView(View):
                     with_local = True
                     outputs['local'] = {'id': 'local', 'data': Helper.term_message('等待初始化...        ')}
             elif req.deploy.extend == '2':
-                s_actions = json.loads(req.deploy.extend_obj.server_actions)
-                h_actions = json.loads(req.deploy.extend_obj.host_actions)
+                extend_obj = req.deploy.extend_obj
+                if req.type == '2':
+                    s_actions = json.loads(extend_obj.rollback_server_actions) if extend_obj.rollback_server_actions else []
+                    h_actions = json.loads(extend_obj.rollback_host_actions) if extend_obj.rollback_host_actions else []
+                else:
+                    s_actions = json.loads(extend_obj.server_actions)
+                    h_actions = json.loads(extend_obj.host_actions)
                 if s_actions:
                     if deploy_status.get('local') == '2':
                         outputs['local'] = {
@@ -334,6 +353,37 @@ def post_request_ext2(request):
             is_required_notify = deploy.is_audit
         if is_required_notify:
             Thread(target=Helper.send_deploy_notify, args=(req, 'approve_req')).start()
+    return json_response(error=error)
+
+
+@auth('deploy.request.do')
+def post_request_ext2_rollback(request):
+    form, error = JsonParser(
+        Argument('request_id', type=int, help='请选择要回滚的版本'),
+        Argument('name', help='请输入申请标题'),
+        Argument('host_ids', type=list, filter=lambda x: len(x), help='请选择要部署的主机'),
+        Argument('desc', required=False),
+    ).parse(request.body)
+    if error is None:
+        req = DeployRequest.objects.get(pk=form.pop('request_id'))
+        extend_obj = req.deploy.extend_obj
+        s_acts = json.loads(extend_obj.rollback_server_actions) if extend_obj.rollback_server_actions else []
+        h_acts = json.loads(extend_obj.rollback_host_actions) if extend_obj.rollback_host_actions else []
+        if not s_acts and not h_acts:
+            return json_response(error='该发布配置未设置回滚动作，无法回滚，请先在发布配置中配置回滚动作')
+        form.status = '0' if req.deploy.is_audit else '1'
+        form.host_ids = json.dumps(sorted(form.host_ids))
+        new_req = DeployRequest.objects.create(
+            deploy_id=req.deploy_id,
+            type='2',
+            extra=req.extra,
+            version=req.version,
+            spug_version=req.spug_version,
+            created_by=request.user,
+            **form
+        )
+        if req.deploy.is_audit:
+            Thread(target=Helper.send_deploy_notify, args=(new_req, 'approve_req')).start()
     return json_response(error=error)
 
 

--- a/spug_web/src/pages/deploy/app/AddSelect.js
+++ b/spug_web/src/pages/deploy/app/AddSelect.js
@@ -33,7 +33,9 @@ class AddSelect extends React.Component {
       rst_notify: {mode: '0'},
       host_ids: [],
       host_actions: [],
-      server_actions: []
+      server_actions: [],
+      rollback_host_actions: [],
+      rollback_server_actions: []
     }
   };
 

--- a/spug_web/src/pages/deploy/app/Ext2Setup2.js
+++ b/spug_web/src/pages/deploy/app/Ext2Setup2.js
@@ -35,6 +35,8 @@ class Ext2Setup2 extends React.Component {
     info['extend'] = '2';
     info['host_actions'] = info['host_actions'].filter(x => (x.title && x.data) || (x.title && (x.src || x.src_mode === '1') && x.dst));
     info['server_actions'] = info['server_actions'].filter(x => x.title && x.data);
+    info['rollback_host_actions'] = (info['rollback_host_actions'] || []).filter(x => x.title && x.data);
+    info['rollback_server_actions'] = (info['rollback_server_actions'] || []).filter(x => x.title && x.data);
     http.post('/api/app/deploy/', info)
       .then(res => {
         message.success(t('保存成功'));
@@ -65,9 +67,21 @@ class Ext2Setup2 extends React.Component {
     this._doAction(actions, index, action)
   }
 
+  handleRollbackServerAction = (index, action) => {
+    const actions = store.deploy['rollback_server_actions'];
+    this._doAction(actions, index, action)
+  }
+
+  handleRollbackHostAction = (index, action) => {
+    const actions = store.deploy['rollback_host_actions'];
+    this._doAction(actions, index, action)
+  }
+
   render() {
     const server_actions = store.deploy['server_actions'];
     const host_actions = store.deploy['host_actions'];
+    const rollback_server_actions = store.deploy['rollback_server_actions'] || [];
+    const rollback_host_actions = store.deploy['rollback_host_actions'] || [];
     return (
       <Form labelCol={{span: 6}} wrapperCol={{span: 14}} className={styles.ext2Form}>
         {store.deploy.id === undefined && (
@@ -210,6 +224,90 @@ class Ext2Setup2 extends React.Component {
               disabled={store.isReadOnly || lds.findIndex(host_actions, x => x.type === 'transfer') !== -1}
               onClick={() => host_actions.push({type: 'transfer', title: '数据传输', mode: '0', src_mode: '0'})}>
               <PlusOutlined/>{t('添加数据传输动作（仅能添加一个）')}
+            </Button>
+          </Form.Item>
+        )}
+        <Divider orientation="left">{t('回滚动作（可选）')}</Divider>
+        <Alert
+          closable
+          showIcon
+          type="info"
+          message={t('回滚动作')}
+          style={{margin: '0 80px 20px'}}
+          description={t('当发布申请执行回滚时，将按顺序执行以下回滚动作。留空则该发布配置不支持回滚。')}
+        />
+        {rollback_server_actions.map((item, index) => (
+          <div key={index} style={{marginBottom: 30, position: 'relative'}}>
+            <Form.Item label={t('回滚本地动作{}', index + 1)}>
+              <Input disabled={store.isReadOnly} value={item['title']} onChange={e => item['title'] = e.target.value}
+                     placeholder={t('请输入')}/>
+            </Form.Item>
+
+            <Form.Item label={t('执行内容')}>
+              <ACEditor
+                readOnly={store.isReadOnly}
+                mode="sh"
+                theme="tomorrow"
+                width="100%"
+                height="100px"
+                value={item['data']}
+                onChange={v => item['data'] = cleanCommand(v)}
+                placeholder={t('请输入要执行的回滚动作')}/>
+            </Form.Item>
+            {!store.isReadOnly && (
+              <React.Fragment>
+                <Button type="dashed" icon={<UpOutlined/>} className={styles.upAction}
+                        onClick={() => this.handleRollbackServerAction(index, 'up')}/>
+                <div className={styles.delAction} onClick={() => rollback_server_actions.splice(index, 1)}>
+                  <MinusCircleOutlined/>{t('移除')}
+                </div>
+                <Button type="dashed" icon={<DownOutlined/>} className={styles.downAction}
+                        onClick={() => this.handleRollbackServerAction(index, 'down')}/>
+              </React.Fragment>
+            )}
+          </div>
+        ))}
+        {!store.isReadOnly && (
+          <Form.Item wrapperCol={{span: 14, offset: 6}}>
+            <Button type="dashed" block onClick={() => rollback_server_actions.push({})}>
+              <PlusOutlined/>{t('添加回滚本地执行动作（在服务端本地执行）')}
+            </Button>
+          </Form.Item>
+        )}
+        {rollback_host_actions.map((item, index) => (
+          <div key={index} style={{marginBottom: 30, position: 'relative'}}>
+            <Form.Item label={t('回滚目标主机动作{}', index + 1)}>
+              <Input disabled={store.isReadOnly} value={item['title']} onChange={e => item['title'] = e.target.value}
+                     placeholder={t('请输入')}/>
+            </Form.Item>
+            <Form.Item label={t('执行内容')}>
+              <ACEditor
+                readOnly={store.isReadOnly}
+                mode="sh"
+                theme="tomorrow"
+                width="100%"
+                height="100px"
+                value={item['data']}
+                onChange={v => item['data'] = cleanCommand(v)}
+                placeholder={t('请输入要执行的回滚动作')}/>
+            </Form.Item>
+            {!store.isReadOnly && (
+              <React.Fragment>
+                <Button type="dashed" icon={<UpOutlined/>} className={styles.upAction}
+                        onClick={() => this.handleRollbackHostAction(index, 'up')}/>
+                <div className={styles.delAction} onClick={() => rollback_host_actions.splice(index, 1)}>
+                  <MinusCircleOutlined/>{t('移除')}
+                </div>
+                <Button type="dashed" icon={<DownOutlined/>} className={styles.downAction}
+                        onClick={() => this.handleRollbackHostAction(index, 'down')}/>
+              </React.Fragment>
+            )}
+          </div>
+        ))}
+        {!store.isReadOnly && (
+          <Form.Item wrapperCol={{span: 14, offset: 6}}>
+            <Button type="dashed" block onClick={() => rollback_host_actions.push({})}>
+              <PlusOutlined/>{t('添加回滚目标主机执行动作（在部署目标主机执行）')}
             </Button>
           </Form.Item>
         )}

--- a/spug_web/src/pages/deploy/request/Rollback.js
+++ b/spug_web/src/pages/deploy/request/Rollback.js
@@ -31,7 +31,10 @@ export default observer(function () {
     setLoading(true);
     const formData = form.getFieldsValue();
     formData['host_ids'] = host_ids;
-    http.post('/api/deploy/request/ext1/rollback/', formData)
+    const rollbackUrl = store.record.app_extend === '2'
+      ? '/api/deploy/request/ext2/rollback/'
+      : '/api/deploy/request/ext1/rollback/';
+    http.post(rollbackUrl, formData)
       .then(res => {
         message.success(t('操作成功'));
         store.rollbackVisible = false;
@@ -39,7 +42,12 @@ export default observer(function () {
       }, () => setLoading(false))
   }
 
-  const {app_host_ids, deploy_id, deploy_status} = store.record;
+  const {app_host_ids, deploy_id, deploy_status, app_extend} = store.record;
+  const rollbackRecords = store.records.filter(x => {
+    if (x.deploy_id !== deploy_id || !['3', '-3'].includes(x.status)) return false;
+    if (app_extend === '1') return x.repository_id;
+    return true;
+  });
   return (
     <Modal
       open
@@ -58,7 +66,7 @@ export default observer(function () {
             showSearch
             placeholder={t('请选择回滚至哪个版本')}
             filterOption={(input, option) => includes(option.props.children, input)}>
-            {store.records.filter(x => x.repository_id && x.deploy_id === deploy_id && ['3', '-3'].includes(x.status)).map((item, index) => (
+            {rollbackRecords.map((item, index) => (
               <Select.Option key={item.id} value={item.id} record={item} disabled={index === 0}>
                 <div style={{display: 'flex', justifyContent: 'space-between'}}>
                   <span>{`${item.name} (${item.version})`}</span>

--- a/spug_web/src/pages/deploy/request/store.js
+++ b/spug_web/src/pages/deploy/request/store.js
@@ -109,7 +109,7 @@ class Store {
   };
 
   rollback = (info) => {
-    this.record = lds.pick(info, ['app_id', 'deploy_id', 'host_ids', 'deploy_status']);
+    this.record = lds.pick(info, ['app_id', 'deploy_id', 'host_ids', 'deploy_status', 'app_extend']);
     this.record.app_host_ids = info.host_ids;
     this.record.name = t('{} - 回滚', info.name);
     this.rollbackVisible = true


### PR DESCRIPTION
## Related Issue
Closes #731

## Background
Issue #731 requests a **rollback button** for custom (ext2) deploys, letting users write their own rollback logic via scripts. Previously only regular (ext1) deploys supported rollback; custom deploys had no rollback path at all.

## Changes

### Backend
- **`apps/app/models.py`** — `DeployExtend2`: add nullable `rollback_server_actions` / `rollback_host_actions` `TextField`s. `to_dict` exposes them as arrays (default `[]`).
- **`apps/app/views.py`** — `DeployView.post` (ext2 branch): parse and persist the two new rollback action lists (default `[]`), json-dumped like the normal actions.
- **`apps/deploy/ext2.py`** — `ext2_deploy`: when `req.type == '2'`, load the rollback actions instead of the normal actions; if both are empty, raise a clear error (`该发布配置未设置回滚动作，无法回滚`). The rest of the dispatch (local execution, transfer packing, per-host SSH) is reused unchanged.
- **`apps/deploy/utils.py`** — `dispatch_all`: compute `with_local` from the rollback server actions for `type == '2'` requests.
- **`apps/deploy/views.py`**:
  - `RequestView.get`: set `visible_rollback` for ext2 deploys that have rollback actions configured (latest request per deploy only, mirroring ext1).
  - `RequestDetailView.get` / `RequestDetailView.post`: derive `s_actions` / `h_actions` from the rollback actions for `type == '2'` requests, so the console outputs and `with_local` match.
  - New `post_request_ext2_rollback` (`@auth('deploy.request.do')`): creates a `DeployRequest(type='2')` copying `version`, `spug_version`, `extra` from the selected prior request; honors `is_audit` and sends the approve notification.
- **`apps/deploy/urls.py`** — add `request/ext2/rollback/` route.

### Frontend
- **`pages/deploy/app/Ext2Setup2.js`** — add an optional **Rollback Actions** editor section (local + target-host shell actions), mirroring the existing action editors, clearly marked as optional.
- **`pages/deploy/app/AddSelect.js`** — default `rollback_host_actions` / `rollback_server_actions` to `[]` for new ext2 deploys.
- **`pages/deploy/request/Rollback.js`** — branch by `app_extend`: ext2 posts to `/api/deploy/request/ext2/rollback/` and lists prior requests without the `repository_id` filter (ext2 has no repository).
- **`pages/deploy/request/store.js`** — `rollback(info)` now passes `app_extend` so the dialog can pick the correct API endpoint.

## How it works
1. In a custom deploy config (ext2), the user optionally adds rollback actions (local and/or target-host shell scripts) — same editor UX as normal actions.
2. On the deploy request list, the latest successful/failed request for an ext2 deploy with rollback actions configured shows a **回滚** button.
3. Clicking it opens the existing rollback dialog; the user picks a prior version to roll back to and selects target hosts.
4. Submitting creates a new `type='2'` deploy request. When dispatched, `ext2_deploy` runs the configured rollback actions instead of the normal actions. Scripts can detect rollback mode via the existing `$SPUG_DEPLOY_TYPE` env var (value `2`).

## Affected Versions
- **Branch**: `4.0` (`SPUG_VERSION = v4.0.0`, upstream HEAD `57ba33b`).
- Only the `ext2` (custom deploy) code paths are affected. `ext1` (regular deploy) rollback behavior is unchanged.
- No frontend/backend API contracts for existing flows are altered; the new fields default to empty arrays, so existing deploy configs without rollback actions behave exactly as before (no rollback button shown).

## Migration / Setup
A database migration is required for the two new `DeployExtend2` fields. This project does not ship migrations in-repo; after pulling, run:
```
python manage.py updatedb
```
(`updatedb` runs `makemigrations` on all `apps.*` then `migrate`, per the project's established workflow.)

## Verification
- `python -m py_compile` on all modified Python files: pass (syntax clean). Note: Django is not installed in the author's environment, so `manage.py check` / migration generation could not be run locally; the model change is two straightforward nullable `TextField`s following the exact pattern of the existing `server_actions` / `host_actions` fields.
- No lint script or eslint config exists in `spug_web`; frontend changes follow the existing component patterns (observer class, `t()` i18n, antd `Form`/`ACEditor`, mobx `@observable`).
- Manual flow (intended): create an ext2 deploy with rollback actions → run a deploy → on the latest successful/failed request click 回滚 → select a prior version + hosts → confirm the new `type='2'` request runs the rollback actions.

## Regression Risk
Low. The backend only branches on the newly-introduced `req.type == '2'` for ext2 (previously ext2 never produced `type='2'` requests, so existing ext2 deploys are unaffected). The new model fields are nullable with array defaults. The frontend additions are isolated to a new editor section and a URL/filter branch keyed on `app_extend`.